### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-14
+
+### Added
+
+- **Settings screen** — new settings panel accessible from the sidebar gear
+  icon (⚙). Users can now configure persistent preferences that survive across
+  sessions. Settings are stored globally in `localStorage`. (#5, #11)
+- **Default model setting** — choose which model is pre-selected for new
+  messages, instead of relying on the hardcoded constant.
+- **Default planner type setting** — choose between Fast (conversational) and
+  Plan (multi-step structured) as the default planner mode.
+- New `useClientSettings` hook for global settings management with cross-tab
+  sync via `storage` events.
+- `SettingsPanel` component at `/:projectSlug/settings` route.
+- `IconGear` and `IconChevronLeft` SVG icons.
+
+### Fixed
+
+- **PWA stale cache on deploy** — `index.html` is no longer precached by the
+  Service Worker, and the `NavigationRoute` has been removed. Navigations now
+  always hit the CDN, ensuring deployments take effect on the next reload
+  without requiring users to clear caches or re-add the PWA. (#11)
+
+### Changed
+
+- Branch naming lint now bypasses the `develop` integration branch. (#13)
+
+### Security
+
+- Bumped `undici` to 7.24.1 (GHSA advisory). (#9)
+- Bumped `express` and `cookie` in proxy dependencies. (#3)
+
 ## [0.2.0] - 2026-03-11
 
 ### Added
@@ -44,6 +76,7 @@ Initial public release.
 - Remote access via Cloudflare Named Tunnel + Pages + Zero Trust
 - Cross-platform support: Linux (Tier 1), Windows (Tier 2), macOS (Tier 3)
 
-[Unreleased]: https://github.com/L1M80/porta/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/L1M80/porta/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/L1M80/porta/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/L1M80/porta/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/L1M80/porta/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "porta",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev.mjs",


### PR DESCRIPTION
## Release v0.3.0

Bump version to 0.3.0 and update CHANGELOG.

### Highlights

- ⚙ **Settings screen** with default model & planner type configuration
- 🔧 **PWA stale cache fix** — deploys now take effect on next reload
- 🔒 Security dependency bumps (undici, express, cookie)
- 🛠 CI: branch naming lint bypass for `develop`

See [CHANGELOG.md](./CHANGELOG.md) for full details.
