### PR TITLE
fix(proxy): add fallback for global LS discovery to fix 502 Bad Gateway

### DIFF
--- a/packages/proxy/src/routing.ts
+++ b/packages/proxy/src/routing.ts
@@ -140,9 +140,15 @@ export async function discoverOwnerInstance(
     const wsOwners = candidates.filter(
       (c) => c.inst.workspaceId && normalizeWorkspaceId(c.inst.workspaceId) === normalWsId,
     );
-    if (wsOwners.length === 0) return null;
-    wsOwners.sort((a, b) => b.stepCount - a.stepCount);
-    return wsOwners[0].inst;
+    if (wsOwners.length > 0) {
+      wsOwners.sort((a, b) => b.stepCount - a.stepCount);
+      return wsOwners[0].inst;
+    }
+    // No LS matched by workspaceId — fall back to the candidate that
+    // actually holds the conversation (e.g. a "global" LS started
+    // without --workspace_id). Pick the one with the most steps.
+    candidates.sort((a, b) => b.stepCount - a.stepCount);
+    return candidates[0].inst;
   }
 
   // No workspace metadata.
@@ -212,7 +218,7 @@ export async function resolveAndCall<T>(
       } catch (err) {
         if (
           err instanceof RPCError &&
-          (err.code === "unavailable" || err.code === "not_found")
+          (err.code === "unavailable" || err.code === "not_found" || err.code === "unknown")
         ) {
           // Affinity LS is dead or lost the conversation — clear stale affinity and re-discover
           conversationAffinity.delete(cascadeId);


### PR DESCRIPTION
## Description
This PR fixes a `502 Bad Gateway` routing error that occurs when connecting to the proxy remotely, specifically when trying to route to "global" Antigravity Language Server instances that were started without a specific `--workspace_id`.
## Problem
Previously, if the `routing.ts` logic couldn't find an exact match for a workspace ID, it would fail to route the connection. Furthermore, when the proxy encountered an `unknown` RPC error while trying to reach a stale or disconnected LS instance, it would not properly clear the cache, leading to persistent 502 errors.
## Solution
1. **Fallback for Global LS:** Updated `discoverOwnerInstance` to include a fallback mechanism. If no instance matches the workspace ID, it now sorts all available candidates by `stepCount` and defaults to the most active one. This ensures global instances are successfully discovered.
2. **Robust Error Handling:** Added the `unknown` error code to the catch block in `resolveAndCall`. Now, if an `unknown` error occurs, the proxy correctly clears the stale `conversationAffinity` cache and forces a re-discovery instead of failing.
## Impact
- Fixes remote access (e.g., from mobile devices via PWA) to global chat instances.
- Improves proxy resilience by properly recovering from `unknown` RPC errors.