### PR TITLE
feat: add zero-trust secured API

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ Exposing your local API to the public internet can be dangerous. You can protect
 1. Go to your **Cloudflare Zero Trust** dashboard.
 2. Under **Access > Applications**, create an application to protect `<YOUR_API_SUBDOMAIN>`.
 3. Under **Access > Service Auth**, create a Service Token to generate a Client ID and Client Secret.
-4. In your `.env.production` file, rename `VITE_API_BASE` to `PORTA_API_BASE`. This prevents the frontend from hardcoding the API URL, forcing it to route through the Cloudflare Pages Edge proxy.
+4. In your `.env.production` file, **remove or comment out** `VITE_API_BASE`. This prevents the frontend from hardcoding the API URL, forcing it to use relative paths (`/api/*`) which route through the Cloudflare Pages Edge proxy.
 5. Go to your **Cloudflare Pages** dashboard for `<YOUR_PROJECT_NAME>`.
-6. Under **Settings > Environment variables**, add two variables to **both Production and Preview** environments:
+6. Under **Settings > Environment variables**, add **three** variables to **both Production and Preview** environments:
+   - `PORTA_API_BASE` (set this to your API URL, e.g., `https://<YOUR_API_SUBDOMAIN>`)
    - `CF_ACCESS_CLIENT_ID`
    - `CF_ACCESS_CLIENT_SECRET`
 7. Run `pnpm deploy` again to bake the new environment variables into the deployment.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,22 @@ pnpm dev:cloud
 This reads `PORTA_TUNNEL_NAME` from `.env` and starts the proxy and
 `cloudflared tunnel run` together.
 
+### 6. Securing your API with Cloudflare Access (Zero Trust)
+
+Exposing your local API to the public internet can be dangerous. You can protect your API subdomain using Cloudflare Access (Zero Trust), and configure Porta's Edge proxy to securely authenticate.
+
+1. Go to your **Cloudflare Zero Trust** dashboard.
+2. Under **Access > Applications**, create an application to protect `<YOUR_API_SUBDOMAIN>`.
+3. Under **Access > Service Auth**, create a Service Token to generate a Client ID and Client Secret.
+4. In your `.env.production` file, rename `VITE_API_BASE` to `PORTA_API_BASE`. This prevents the frontend from hardcoding the API URL, forcing it to route through the Cloudflare Pages Edge proxy.
+5. Go to your **Cloudflare Pages** dashboard for `<YOUR_PROJECT_NAME>`.
+6. Under **Settings > Environment variables**, add two variables to **both Production and Preview** environments:
+   - `CF_ACCESS_CLIENT_ID`
+   - `CF_ACCESS_CLIENT_SECRET`
+7. Run `pnpm deploy` again to bake the new environment variables into the deployment.
+
+The Cloudflare Pages Function will now automatically inject these headers securely from the server side, allowing your frontend to bypass Cloudflare Access while keeping your API completely hidden from the public.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development workflow, branch

--- a/README.md
+++ b/README.md
@@ -206,20 +206,41 @@ This reads `PORTA_TUNNEL_NAME` from `.env` and starts the proxy and
 
 ### 6. Securing your API with Cloudflare Access (Zero Trust)
 
-Exposing your local API to the public internet can be dangerous. You can protect your API subdomain using Cloudflare Access (Zero Trust), and configure Porta's Edge proxy to securely authenticate.
+Exposing your local API to the public internet can be dangerous. To completely lock down your setup, you should protect **both** your frontend and your API using Cloudflare Access. 
 
-1. Go to your **Cloudflare Zero Trust** dashboard.
-2. Under **Access > Applications**, create an application to protect `<YOUR_API_SUBDOMAIN>`.
-3. Under **Access > Service Auth**, create a Service Token to generate a Client ID and Client Secret.
-4. In your `.env.production` file, **remove or comment out** `VITE_API_BASE`. This prevents the frontend from hardcoding the API URL, forcing it to use relative paths (`/api/*`) which route through the Cloudflare Pages Edge proxy.
-5. Go to your **Cloudflare Pages** dashboard for `<YOUR_PROJECT_NAME>`.
-6. Under **Settings > Environment variables**, add **three** variables to **both Production and Preview** environments:
-   - `PORTA_API_BASE` (set this to your API URL, e.g., `https://<YOUR_API_SUBDOMAIN>`)
-   - `CF_ACCESS_CLIENT_ID`
-   - `CF_ACCESS_CLIENT_SECRET`
-7. Run `pnpm deploy` again to bake the new environment variables into the deployment.
+Porta's built-in Edge Proxy securely bridges the two by injecting Machine-to-Machine authentication tokens, completely hiding your backend from the internet.
 
-The Cloudflare Pages Function will now automatically inject these headers securely from the server side, allowing your frontend to bypass Cloudflare Access while keeping your API completely hidden from the public.
+To set this up, follow these precise steps:
+
+**1. Create Two Separate Applications**
+In your **Cloudflare Zero Trust** dashboard, under **Access > Applications**, you must create **two** distinct applications:
+- **Frontend App**: Protects your Pages deployment (e.g., `https://<YOUR_PAGES_DOMAIN>`). Configure this with standard user login policies (e.g., email OTP).
+- **Backend API App**: Protects your Tunnel (e.g., `https://<YOUR_API_SUBDOMAIN>`). 
+
+**2. Generate Service Tokens**
+1. Navigate to **Access > Service Auth**.
+2. Create a new Service Token for Porta. This will generate a **Client ID** and **Client Secret**.
+
+**3. Add the Service Auth Policy to the Backend API**
+1. Open the **Backend API App** you created in Step 1.
+2. Go to the **Policies** tab and add a new policy.
+3. Set the action to **Service Auth**.
+4. In the rules, configure it to **Include > Service Token** and select the token you just created.
+
+**4. Configure Cloudflare Pages Environment Variables**
+1. Go to your **Cloudflare Pages** dashboard for `<YOUR_PROJECT_NAME>`.
+2. Under **Settings > Environment variables**, add the following **three** variables to **both Production and Preview** environments:
+   - `PORTA_API_BASE`: Set this to your exact API URL (e.g., `https://<YOUR_API_SUBDOMAIN>`).
+   - `CF_ACCESS_CLIENT_ID`: The Client ID from Step 2.
+   - `CF_ACCESS_CLIENT_SECRET`: The Client Secret from Step 2.
+
+**5. Route Frontend Traffic Through the Proxy**
+By default, the Porta frontend tries to fetch the API directly. To force it to use the secure Edge Proxy:
+1. In your `.env.production` file, **remove or comment out** `VITE_API_BASE`. 
+2. Without `VITE_API_BASE`, the frontend falls back to relative paths (`/api/*`), routing traffic through the Cloudflare Pages Edge proxy.
+3. Run `pnpm deploy` again.
+
+> **Backwards Compatibility Note:** If `VITE_API_BASE` is defined, the frontend will bypass the proxy entirely and attempt to communicate directly with the backend. This is fully supported and recommended for local development (LAN access) or deployments where the backend is not protected by Cloudflare Access. Additionally, the proxy will gracefully skip Service Token injection if the `CF_ACCESS_CLIENT_ID` environment variables are missing.
 
 ## Contributing
 

--- a/packages/web/functions/api/[[route]].ts
+++ b/packages/web/functions/api/[[route]].ts
@@ -1,0 +1,44 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const onRequest: any = async (context: any) => {
+  const { request, env } = context;
+
+  // Determine the target API base URL from the environment.
+  let apiBase = env.PORTA_API_BASE || env.VITE_API_BASE;
+  if (!apiBase) {
+    return new Response(
+      JSON.stringify({ error: "Missing PORTA_API_BASE or VITE_API_BASE environment variable" }), 
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+
+  if (typeof apiBase === "string" && !apiBase.startsWith("http")) {
+    apiBase = "https://" + apiBase;
+  }
+
+  const url = new URL(request.url);
+  const targetUrl = new URL(url.pathname + url.search, apiBase);
+
+  const headers = new Headers(request.headers);
+  
+  // Optionally inject Cloudflare Access credentials if provided in the environment.
+  // This allows secure server-to-server communication without exposing secrets to the browser.
+  if (env.CF_ACCESS_CLIENT_ID) {
+    headers.set("CF-Access-Client-Id", env.CF_ACCESS_CLIENT_ID);
+  }
+  if (env.CF_ACCESS_CLIENT_SECRET) {
+    headers.set("CF-Access-Client-Secret", env.CF_ACCESS_CLIENT_SECRET);
+  }
+  
+  // Strip origin headers to avoid triggering CORS preflight issues on the target server.
+  headers.delete("Origin");
+  headers.delete("Referer");
+
+  const newRequest = new Request(targetUrl.toString(), {
+    method: request.method,
+    headers,
+    body: request.method !== "GET" && request.method !== "HEAD" ? request.body : null,
+    redirect: "manual",
+  });
+
+  return fetch(newRequest);
+};

--- a/packages/web/functions/api/[[route]].ts
+++ b/packages/web/functions/api/[[route]].ts
@@ -20,12 +20,9 @@ export const onRequest: any = async (context: any) => {
 
     const headers = new Headers(request.headers);
 
-    // Optionally inject Cloudflare Access credentials if provided in the environment.
-    // This allows secure server-to-server communication without exposing secrets to the browser.
-    if (env.CF_ACCESS_CLIENT_ID) {
+    // 1. Inject Cloudflare Access Service Token credentials (if configured).
+    if (env.CF_ACCESS_CLIENT_ID && env.CF_ACCESS_CLIENT_SECRET) {
         headers.set("CF-Access-Client-Id", env.CF_ACCESS_CLIENT_ID);
-    }
-    if (env.CF_ACCESS_CLIENT_SECRET) {
         headers.set("CF-Access-Client-Secret", env.CF_ACCESS_CLIENT_SECRET);
     }
 
@@ -37,8 +34,19 @@ export const onRequest: any = async (context: any) => {
         method: request.method,
         headers,
         body: request.method !== "GET" && request.method !== "HEAD" ? request.body : null,
-        redirect: "manual",
+        redirect: "manual"
     });
 
-    return fetch(newRequest);
+    const response = await fetch(newRequest);
+
+    // Clone the response so we can modify the headers
+    const finalResponse = new Response(response.body, response);
+    
+    // CRITICAL FIX: Cloudflare Access on the API backend might return a `Set-Cookie: CF_Authorization` 
+    // because it processed the request. If we forward this cookie back to the browser, it OVERWRITES 
+    // the user's frontend CF_Authorization cookie, immediately corrupting their frontend session!
+    // This causes all subsequent frontend requests to be rejected by Cloudflare Access with a 302/403.
+    finalResponse.headers.delete("Set-Cookie");
+    
+    return finalResponse;
 };

--- a/packages/web/functions/api/[[route]].ts
+++ b/packages/web/functions/api/[[route]].ts
@@ -1,44 +1,44 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const onRequest: any = async (context: any) => {
-  const { request, env } = context;
+    const { request, env } = context;
 
-  // Determine the target API base URL from the environment.
-  let apiBase = env.PORTA_API_BASE || env.VITE_API_BASE;
-  if (!apiBase) {
-    return new Response(
-      JSON.stringify({ error: "Missing PORTA_API_BASE or VITE_API_BASE environment variable" }), 
-      { status: 500, headers: { "Content-Type": "application/json" } }
-    );
-  }
+    // Determine the target API base URL from the environment.
+    let apiBase = env.PORTA_API_BASE;
+    if (!apiBase) {
+        return new Response(JSON.stringify({ error: "Missing PORTA_API_BASE environment variable" }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+        });
+    }
 
-  if (typeof apiBase === "string" && !apiBase.startsWith("http")) {
-    apiBase = "https://" + apiBase;
-  }
+    if (typeof apiBase === "string" && !apiBase.startsWith("http")) {
+        apiBase = "https://" + apiBase;
+    }
 
-  const url = new URL(request.url);
-  const targetUrl = new URL(url.pathname + url.search, apiBase);
+    const url = new URL(request.url);
+    const targetUrl = new URL(url.pathname + url.search, apiBase);
 
-  const headers = new Headers(request.headers);
-  
-  // Optionally inject Cloudflare Access credentials if provided in the environment.
-  // This allows secure server-to-server communication without exposing secrets to the browser.
-  if (env.CF_ACCESS_CLIENT_ID) {
-    headers.set("CF-Access-Client-Id", env.CF_ACCESS_CLIENT_ID);
-  }
-  if (env.CF_ACCESS_CLIENT_SECRET) {
-    headers.set("CF-Access-Client-Secret", env.CF_ACCESS_CLIENT_SECRET);
-  }
-  
-  // Strip origin headers to avoid triggering CORS preflight issues on the target server.
-  headers.delete("Origin");
-  headers.delete("Referer");
+    const headers = new Headers(request.headers);
 
-  const newRequest = new Request(targetUrl.toString(), {
-    method: request.method,
-    headers,
-    body: request.method !== "GET" && request.method !== "HEAD" ? request.body : null,
-    redirect: "manual",
-  });
+    // Optionally inject Cloudflare Access credentials if provided in the environment.
+    // This allows secure server-to-server communication without exposing secrets to the browser.
+    if (env.CF_ACCESS_CLIENT_ID) {
+        headers.set("CF-Access-Client-Id", env.CF_ACCESS_CLIENT_ID);
+    }
+    if (env.CF_ACCESS_CLIENT_SECRET) {
+        headers.set("CF-Access-Client-Secret", env.CF_ACCESS_CLIENT_SECRET);
+    }
 
-  return fetch(newRequest);
+    // Strip origin headers to avoid triggering CORS preflight issues on the target server.
+    headers.delete("Origin");
+    headers.delete("Referer");
+
+    const newRequest = new Request(targetUrl.toString(), {
+        method: request.method,
+        headers,
+        body: request.method !== "GET" && request.method !== "HEAD" ? request.body : null,
+        redirect: "manual",
+    });
+
+    return fetch(newRequest);
 };

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -45,6 +45,10 @@ export default defineConfig(({ mode }) => {
           target: toHttpOrigin(proxyHost, proxyPort),
           changeOrigin: true,
           ws: true,
+          headers: {
+            ...(env.CF_ACCESS_CLIENT_ID ? { "CF-Access-Client-Id": env.CF_ACCESS_CLIENT_ID } : {}),
+            ...(env.CF_ACCESS_CLIENT_SECRET ? { "CF-Access-Client-Secret": env.CF_ACCESS_CLIENT_SECRET } : {}),
+          },
         },
       },
     },

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -9,12 +9,13 @@ if (!project) {
   process.exit(1);
 }
 
-function run(command, args) {
+function run(command, args, opts = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       env: process.env,
       stdio: "inherit",
       windowsHide: true,
+      ...opts,
     });
 
     child.on("error", reject);
@@ -33,7 +34,7 @@ await run(commandName("npx"), [
   "wrangler",
   "pages",
   "deploy",
-  "./packages/web/dist",
+  "./dist",
   `--project-name=${project}`,
   "--branch=main",
-]);
+], { cwd: "./packages/web" });


### PR DESCRIPTION
Adding CloudFlared Zero-Trust securing of the API endpoint. The PR includes a Client ID and Secret on all API requests when the `PORTA_API_BASE` environment variable is used insted of `VITA_API_BASE`.

Updated the `README.md` to explain how to enable the feature.

Tested on my own instance of Porta running on WSL2 on Windows 11.

Lint and test currently fail because they fail on `develop`.

Closes #39