### PR TITLE
fix(web): remove deleted conversations from sidebar

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -76,7 +76,7 @@ function ChatView() {
   const activeId = chatId ?? null;
   const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth > 480);
   const isMobile = () => window.innerWidth <= 480;
-  const { conversations, loading, refresh } = useConversations(15_000);
+  const { conversations, loading, refresh, optimisticRemove } = useConversations(15_000);
   const { data: health } = usePolling<HealthResponse>(api.health, 30_000);
 
   // ── Hooks ──
@@ -110,6 +110,7 @@ function ChatView() {
     projectSlug,
     refresh,
     conversations,
+    optimisticRemove,
   });
 
   // Wire handleRevert to also update draft text

--- a/packages/web/src/hooks/useChatActions.ts
+++ b/packages/web/src/hooks/useChatActions.ts
@@ -19,6 +19,7 @@ interface UseChatActionsArgs {
       workspaces?: { workspaceFolderAbsoluteUri?: string }[];
     };
   }[];
+  optimisticRemove?: (id: string) => void;
 }
 
 interface UseChatActionsResult {
@@ -54,6 +55,7 @@ export function useChatActions({
   projectSlug,
   refresh,
   conversations,
+  optimisticRemove,
 }: UseChatActionsArgs): UseChatActionsResult {
   const navigate = useNavigate();
 
@@ -203,6 +205,7 @@ export function useChatActions({
     async (id: string) => {
       try {
         await api.deleteConversation(id);
+        optimisticRemove?.(id);
         if (activeId === id) {
           navigate(`/${projectSlug ?? "unknown"}`);
         }
@@ -211,7 +214,7 @@ export function useChatActions({
         console.error("Failed to delete:", err);
       }
     },
-    [activeId, refresh, navigate, projectSlug],
+    [activeId, refresh, navigate, projectSlug, optimisticRemove],
   );
 
   const triggerSoftRefresh = useCallback(() => {

--- a/packages/web/src/hooks/useConversations.ts
+++ b/packages/web/src/hooks/useConversations.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState, useCallback } from "react";
 import { api } from "../api/client";
 import { usePolling } from "./usePolling";
 import type { ConversationSummary, ConversationsResponse } from "../types";
@@ -14,17 +14,30 @@ export function useConversations(intervalMs = 15_000) {
     intervalMs,
   );
 
+  const [deletedIds, setDeletedIds] = useState<Set<string>>(new Set());
+
+  const optimisticRemove = useCallback((id: string) => {
+    setDeletedIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  }, []);
+
   const conversations = useMemo<ConversationEntry[]>(() => {
     if (!data?.trajectorySummaries) return [];
 
-    return Object.entries(data.trajectorySummaries)
+    const finalArray = Object.entries(data.trajectorySummaries)
+      .filter(([id]) => !deletedIds.has(id))
       .map(([id, summary]) => ({ id, summary }))
       .sort(
         (a, b) =>
           new Date(b.summary.lastModifiedTime).getTime() -
           new Date(a.summary.lastModifiedTime).getTime(),
       );
-  }, [data]);
 
-  return { conversations, error, loading, refresh };
+    return finalArray;
+  }, [data, deletedIds]);
+
+  return { conversations, error, loading, refresh, optimisticRemove };
 }


### PR DESCRIPTION
Closes #6

## Summary

This updates the web UI so a conversation is removed from the sidebar immediately after `api.deleteConversation(id)` succeeds, instead of staying visible until the next polling refresh.

## Changes

- Tracks successfully deleted conversation IDs locally in `useConversations`.
- Filters deleted IDs out of the derived conversation list.
- Wires the optimistic removal callback through `App` into `useChatActions`.
- Preserves the existing `refresh()` call after deletion so polling/server sync behavior still runs.

## Testing

- `pnpm build`
- `pnpm test`

## Manual verification

- Deleted a non-active conversation and confirmed it disappeared from the sidebar immediately.
- Waited past the polling interval and confirmed it did not reappear.
- Deleted the active conversation and confirmed it navigated away from the deleted chat.