### PR TITLE
chore: sync v0.6.0 release metadata to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-12
+
+### Fixed
+
+- **Terminal command approvals now use the current Antigravity LS interaction
+  shape** by sending `permission.allow` to `HandleCascadeUserInteraction`,
+  fixing `unexpected user interaction type: not permission` errors when
+  approving or rejecting proposed commands. (#47)
+
 ## [0.5.0] - 2026-05-04
 
 ### Added
@@ -114,7 +123,8 @@ Initial public release.
 - Remote access via Cloudflare Named Tunnel + Pages + Zero Trust
 - Cross-platform support: Linux (Tier 1), Windows (Tier 2), macOS (Tier 3)
 
-[Unreleased]: https://github.com/L1M80/porta/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/L1M80/porta/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/L1M80/porta/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/L1M80/porta/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/L1M80/porta/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/L1M80/porta/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/L1M80/porta/actions/workflows/ci.yml/badge.svg)](https://github.com/L1M80/porta/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.5.0-green)
+![Version](https://img.shields.io/badge/version-0.6.0-green)
 
 Remote web interface for [Antigravity](https://antigravity.google/) Agent Manager.  
 Access your local Antigravity sessions from your phone, tablet, or any remote browser through a lightweight LSP bridge.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "porta",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev.mjs",

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -584,8 +584,8 @@ export function registerConversationRoutes(app: Hono): void {
           interaction: {
             trajectoryId,
             stepIndex: Number(stepIndex),
-            commandAction: {
-              approved: !!approved,
+            permission: {
+              allow: !!approved,
             },
           },
         },


### PR DESCRIPTION
## Summary

- bring the terminal command approval fix from #47 back to develop
- sync v0.6.0 release metadata after the main release

## Verification

- release PR #48 CI passed
- local release verification: pnpm -r test, pnpm -r build