### PR TITLE
fix(proxy): handle localized netstat listening rows

### DIFF
--- a/packages/proxy/src/__tests__/platform.test.ts
+++ b/packages/proxy/src/__tests__/platform.test.ts
@@ -141,4 +141,18 @@ Active Connections
 
     expect(parseNetstatPorts(output, 123)).toEqual([19222, 19223]);
   });
+
+  it("parses localized netstat listening rows for a pid", () => {
+    const output = `
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    127.0.0.1:19222        0.0.0.0:0              ABHREN          123
+  TCP    127.0.0.1:19223        *:*                    ESCUCHANDO      123
+  TCP    127.0.0.1:9999         127.0.0.1:53210        ESTABLISHED     123
+  TCP    [::]:135               [::]:0                 ABHREN          908
+`;
+
+    expect(parseNetstatPorts(output, 123)).toEqual([19222, 19223]);
+  });
 });

--- a/packages/proxy/src/platform/shared.ts
+++ b/packages/proxy/src/platform/shared.ts
@@ -188,13 +188,18 @@ export function parseNetstatPorts(output: string, pid: number): number[] {
 
   for (const rawLine of output.split("\n")) {
     const line = rawLine.trim();
-    if (!line || !line.includes("LISTENING")) continue;
+    if (!line) continue;
 
     const columns = line.split(/\s+/);
     if (columns.length < 5) continue;
 
     const rowPid = parseInt(columns[columns.length - 1], 10);
     if (rowPid !== pid) continue;
+
+    const remoteAddress = columns[2];
+    const isListening =
+      remoteAddress.endsWith(":0") || remoteAddress.endsWith(":*");
+    if (!isListening) continue;
 
     const localAddress = columns[1];
     const match = localAddress.match(/:(\d+)$/);


### PR DESCRIPTION
## Summary
- remove the English `LISTENING` dependency from Windows `netstat -ano` parsing
- detect listening sockets by wildcard remote addresses ending in `:0` or `:*`
- add coverage for localized Windows netstat state strings

Fixes #52

## Tests
- `pnpm --filter @porta/proxy test`
- `pnpm --filter @porta/proxy build`
- `git diff --check`
