### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-02
+
+### Fixed
+
+- **Antigravity 2.x conversation metadata is now normalized** so workspace and
+  conversation history discovery continues to work when the Language Server
+  reports workspaces under `trajectoryMetadata`. (#56, #57)
+- **Localized Windows `netstat` output is now parsed without relying on the
+  English `LISTENING` state**, fixing local Language Server discovery on
+  non-English Windows installations. (#52, #59)
+
+### Security
+
+- Bumped vulnerable `brace-expansion` transitive dependency versions in the
+  lockfiles. (#53, #54)
+
 ## [0.6.0] - 2026-05-12
 
 ### Fixed
@@ -123,7 +139,8 @@ Initial public release.
 - Remote access via Cloudflare Named Tunnel + Pages + Zero Trust
 - Cross-platform support: Linux (Tier 1), Windows (Tier 2), macOS (Tier 3)
 
-[Unreleased]: https://github.com/L1M80/porta/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/L1M80/porta/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/L1M80/porta/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/L1M80/porta/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/L1M80/porta/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/L1M80/porta/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/L1M80/porta/actions/workflows/ci.yml/badge.svg)](https://github.com/L1M80/porta/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.6.0-green)
+![Version](https://img.shields.io/badge/version-0.7.0-green)
 
 Remote web interface for [Antigravity](https://antigravity.google/) Agent Manager.  
 Access your local Antigravity sessions from your phone, tablet, or any remote browser through a lightweight LSP bridge.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "porta",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev.mjs",

--- a/packages/proxy/src/__tests__/conversations-route.test.ts
+++ b/packages/proxy/src/__tests__/conversations-route.test.ts
@@ -1,0 +1,241 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LSInstance } from "../discovery.js";
+
+const mockGetInstances = vi.fn<() => Promise<LSInstance[]>>();
+const mockRpcCall = vi.fn<
+  (method: string, body: unknown, inst: LSInstance) => Promise<unknown>
+>();
+const mockScanDiskConversations = vi.fn<
+  () => Promise<{ id: string; mtime: string }[]>
+>();
+
+const conversationAffinity = new Map<string, string>();
+const conversationInstanceAffinity = new Map<string, LSInstance>();
+
+vi.mock("../routing.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    discovery: {
+      getInstances: mockGetInstances,
+      getInstance: async () => (await mockGetInstances())[0] ?? null,
+    },
+    rpc: { call: mockRpcCall },
+    conversationAffinity,
+    conversationInstanceAffinity,
+  };
+});
+
+vi.mock("../metadata.js", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    scanDiskConversations: mockScanDiskConversations,
+  };
+});
+
+const { registerConversationRoutes } = await import("../routes/conversations.js");
+
+const makeInstance = (overrides: Partial<LSInstance> = {}): LSInstance => ({
+  pid: 1000 + Math.floor(Math.random() * 9000),
+  httpsPort: 9000 + Math.floor(Math.random() * 1000),
+  httpPort: 0,
+  lspPort: 0,
+  csrfToken: "test-csrf",
+  source: "daemon" as const,
+  ...overrides,
+});
+
+function app() {
+  const hono = new Hono();
+  registerConversationRoutes(hono);
+  return hono;
+}
+
+describe("GET /api/conversations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    conversationAffinity.clear();
+    conversationInstanceAffinity.clear();
+    mockScanDiskConversations.mockResolvedValue([]);
+  });
+
+  it("keeps workspace-backed conversations from an unscoped Antigravity 2.x hub LS", async () => {
+    const hubLS = makeInstance({ pid: 1, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+    mockRpcCall.mockResolvedValue({
+      trajectorySummaries: {
+        "c-hub": {
+          summary: "Hub conversation",
+          stepCount: 9,
+          lastModifiedTime: "2026-06-01T00:00:00.000Z",
+          workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/project" }],
+        },
+      },
+    });
+
+    const res = await app().request("/api/conversations");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(Object.keys(body.trajectorySummaries)).toEqual(["c-hub"]);
+    expect(conversationAffinity.get("c-hub")).toBe("file_home_user_project");
+  });
+
+  it("still filters scoped LS conversations for workspaces not served by any running scoped LS", async () => {
+    const scopedLS = makeInstance({
+      pid: 2,
+      workspaceId: "file_home_user_projectA",
+    });
+    mockGetInstances.mockResolvedValue([scopedLS]);
+    mockRpcCall.mockResolvedValue({
+      trajectorySummaries: {
+        "c-other": {
+          summary: "Other project",
+          stepCount: 9,
+          lastModifiedTime: "2026-06-01T00:00:00.000Z",
+          workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/projectB" }],
+        },
+      },
+    });
+
+    const res = await app().request("/api/conversations");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.trajectorySummaries).toEqual({});
+  });
+
+  it("normalizes workspaces from trajectoryMetadata for frontend consumers", async () => {
+    const hubLS = makeInstance({ pid: 3, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+    mockRpcCall.mockResolvedValue({
+      trajectorySummaries: {
+        "c-meta": {
+          summary: "Metadata-only workspace",
+          stepCount: 9,
+          lastModifiedTime: "2026-06-01T00:00:00.000Z",
+          trajectoryMetadata: {
+            workspaces: [
+              { workspaceFolderAbsoluteUri: "file:///home/user/project" },
+            ],
+          },
+        },
+      },
+    });
+
+    const res = await app().request("/api/conversations");
+    const body = await res.json();
+
+    expect(body.trajectorySummaries["c-meta"].workspaces).toEqual([
+      { workspaceFolderAbsoluteUri: "file:///home/user/project" },
+    ]);
+  });
+});
+
+describe("POST /api/conversations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    conversationAffinity.clear();
+    conversationInstanceAffinity.clear();
+    mockScanDiskConversations.mockResolvedValue([]);
+  });
+
+  it("sets the Antigravity 2.x required trajectory source and caches unscoped hub ownership", async () => {
+    const hubLS = makeInstance({ pid: 4, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+    mockRpcCall.mockResolvedValue({ cascadeId: "new-cascade" });
+
+    const res = await app().request("/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        workspaceFolderAbsoluteUri: "file:///home/user/project",
+        fileAccessGranted: true,
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.cascadeId).toBe("new-cascade");
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      "StartCascade",
+      expect.objectContaining({
+        source: "CORTEX_TRAJECTORY_SOURCE_CASCADE_CLIENT",
+        workspaceFolderAbsoluteUri: "file:///home/user/project",
+        workspaceUris: ["file:///home/user/project"],
+      }),
+      hubLS,
+    );
+    expect(conversationAffinity.get("new-cascade")).toBe(
+      "file_home_user_project",
+    );
+    expect(conversationInstanceAffinity.get("new-cascade")).toBe(hubLS);
+  });
+
+  it("accepts latest Antigravity workspaceUris requests", async () => {
+    const hubLS = makeInstance({ pid: 5, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+    mockRpcCall.mockResolvedValue({ cascadeId: "new-cascade" });
+
+    const res = await app().request("/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        workspaceUris: ["file:///home/user/project"],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      "StartCascade",
+      expect.objectContaining({
+        workspaceFolderAbsoluteUri: "file:///home/user/project",
+        workspaceUris: ["file:///home/user/project"],
+      }),
+      hubLS,
+    );
+    expect(conversationAffinity.get("new-cascade")).toBe(
+      "file_home_user_project",
+    );
+  });
+
+  it("infers a single known workspace when creating without workspace metadata", async () => {
+    const hubLS = makeInstance({ pid: 6, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+    mockRpcCall.mockImplementation(async (method) => {
+      if (method === "GetWorkspaceInfos") return { workspaceInfos: [] };
+      if (method === "GetAllCascadeTrajectories") {
+        return {
+          trajectorySummaries: {
+            existing: {
+              trajectoryMetadata: {
+                workspaces: [
+                  { workspaceFolderAbsoluteUri: "file:///home/user/project" },
+                ],
+              },
+            },
+          },
+        };
+      }
+      return { cascadeId: "new-cascade" };
+    });
+
+    const res = await app().request("/api/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ fileAccessGranted: true }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      "StartCascade",
+      expect.objectContaining({
+        workspaceFolderAbsoluteUri: "file:///home/user/project",
+        workspaceUris: ["file:///home/user/project"],
+      }),
+      hubLS,
+    );
+  });
+});

--- a/packages/proxy/src/__tests__/metadata.test.ts
+++ b/packages/proxy/src/__tests__/metadata.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getMetadata } from "../metadata.js";
+import {
+  extractConversationWorkspaces,
+  getMetadata,
+  getPrimaryWorkspaceUri,
+  withNormalizedConversationWorkspaces,
+} from "../metadata.js";
 
 describe("getMetadata", () => {
   it("returns base fields without file access", async () => {
@@ -29,5 +34,59 @@ describe("getMetadata", () => {
     const b = await getMetadata();
     expect(a).not.toBe(b);
     expect(a).toEqual(b);
+  });
+});
+
+describe("conversation workspace metadata helpers", () => {
+  it("extracts top-level workspace metadata", () => {
+    const summary = {
+      workspaces: [
+        {
+          workspaceFolderAbsoluteUri: "file:///home/user/project",
+          gitRootAbsoluteUri: "file:///home/user/project",
+          repository: { computedName: "local/project" },
+          branchName: "main",
+        },
+      ],
+    };
+
+    expect(getPrimaryWorkspaceUri(summary)).toBe("file:///home/user/project");
+    expect(extractConversationWorkspaces(summary)[0]).toEqual({
+      workspaceFolderAbsoluteUri: "file:///home/user/project",
+      gitRootAbsoluteUri: "file:///home/user/project",
+      repository: { computedName: "local/project" },
+      branchName: "main",
+    });
+  });
+
+  it("falls back to trajectoryMetadata.workspaces", () => {
+    const summary = {
+      trajectoryMetadata: {
+        workspaces: [
+          { workspaceFolderAbsoluteUri: "file:///tmp/from-metadata" },
+        ],
+      },
+    };
+
+    expect(getPrimaryWorkspaceUri(summary)).toBe("file:///tmp/from-metadata");
+    const normalized = withNormalizedConversationWorkspaces(
+      summary as Record<string, unknown>,
+    );
+
+    expect(normalized.workspaces).toEqual([
+      { workspaceFolderAbsoluteUri: "file:///tmp/from-metadata" },
+    ]);
+  });
+
+  it("falls back to trajectoryMetadata.workspaceUris", () => {
+    const summary = {
+      trajectoryMetadata: {
+        workspaceUris: ["file:///tmp/from-uri"],
+      },
+    };
+
+    expect(extractConversationWorkspaces(summary)).toEqual([
+      { workspaceFolderAbsoluteUri: "file:///tmp/from-uri" },
+    ]);
   });
 });

--- a/packages/proxy/src/__tests__/platform.test.ts
+++ b/packages/proxy/src/__tests__/platform.test.ts
@@ -141,4 +141,18 @@ Active Connections
 
     expect(parseNetstatPorts(output, 123)).toEqual([19222, 19223]);
   });
+
+  it("parses localized netstat listening rows for a pid", () => {
+    const output = `
+Active Connections
+
+  Proto  Local Address          Foreign Address        State           PID
+  TCP    127.0.0.1:19222        0.0.0.0:0              ABHREN          123
+  TCP    127.0.0.1:19223        *:*                    ESCUCHANDO      123
+  TCP    127.0.0.1:9999         127.0.0.1:53210        ESTABLISHED     123
+  TCP    [::]:135               [::]:0                 ABHREN          908
+`;
+
+    expect(parseNetstatPorts(output, 123)).toEqual([19222, 19223]);
+  });
 });

--- a/packages/proxy/src/__tests__/routing-readonly.test.ts
+++ b/packages/proxy/src/__tests__/routing-readonly.test.ts
@@ -44,6 +44,7 @@ const {
   resolveAndCall,
   getStepCount,
   conversationAffinity,
+  conversationInstanceAffinity,
   discoverOwnerInstance,
 } = await import("../routing.js");
 
@@ -63,6 +64,7 @@ describe("discoverOwnerInstance", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     conversationAffinity.clear();
+    conversationInstanceAffinity.clear();
   });
 
   it("returns null when no LS knows about the conversation", async () => {
@@ -88,6 +90,64 @@ describe("discoverOwnerInstance", () => {
     // Works for both readOnly=true and readOnly=false
     expect(await discoverOwnerInstance("c1", [ownerLS, otherLS], true)).toBe(ownerLS);
     expect(await discoverOwnerInstance("c1", [ownerLS, otherLS], false)).toBe(ownerLS);
+  });
+
+  it("routes to a single unscoped hub LS when workspace metadata is present", async () => {
+    const hubLS = makeInstance({ pid: 4, workspaceId: undefined });
+
+    mockRpcCall.mockResolvedValue({
+      trajectorySummaries: {
+        "c-hub": {
+          stepCount: 30,
+          status: "CASCADE_RUN_STATUS_IDLE",
+          workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/projectA" }],
+        },
+      },
+    });
+
+    expect(await discoverOwnerInstance("c-hub", [hubLS], true)).toBe(hubLS);
+    expect(await discoverOwnerInstance("c-hub", [hubLS], false)).toBe(hubLS);
+  });
+
+  it("keeps writes conservative when multiple unscoped LSes report a workspace-backed conversation", async () => {
+    const hubA = makeInstance({ pid: 5, workspaceId: undefined });
+    const hubB = makeInstance({ pid: 6, workspaceId: undefined });
+
+    mockRpcCall.mockResolvedValue({
+      trajectorySummaries: {
+        "c-ambiguous": {
+          stepCount: 30,
+          status: "CASCADE_RUN_STATUS_IDLE",
+          workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/projectA" }],
+        },
+      },
+    });
+
+    expect(
+      await discoverOwnerInstance("c-ambiguous", [hubA, hubB], false),
+    ).toBeNull();
+  });
+
+  it("uses RUNNING status for read-only resolution when multiple unscoped LSes report metadata", async () => {
+    const idleLS = makeInstance({ pid: 7, workspaceId: undefined });
+    const runningLS = makeInstance({ pid: 8, workspaceId: undefined });
+
+    mockRpcCall.mockImplementation(async (_method: string, _body: unknown, inst: LSInstance) => ({
+      trajectorySummaries: {
+        "c-read-hub": {
+          stepCount: inst === idleLS ? 100 : 50,
+          status:
+            inst === runningLS
+              ? "CASCADE_RUN_STATUS_RUNNING"
+              : "CASCADE_RUN_STATUS_IDLE",
+          workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/projectA" }],
+        },
+      },
+    }));
+
+    expect(
+      await discoverOwnerInstance("c-read-hub", [idleLS, runningLS], true),
+    ).toBe(runningLS);
   });
 
   it("picks RUNNING LS when readOnly=true and no workspace metadata", async () => {
@@ -135,6 +195,24 @@ describe("discoverOwnerInstance", () => {
     // Even though a RUNNING LS exists, write path must NOT use heuristics
     const owner = await discoverOwnerInstance("c-write-safe", [staleLS, runningLS], false);
     expect(owner).toBeNull();
+  });
+
+  it("routes writes to a single unscoped hub LS even without workspace metadata", async () => {
+    const hubLS = makeInstance({ pid: 12, workspaceId: undefined });
+
+    mockRpcCall.mockResolvedValue({
+      trajectorySummaries: {
+        "c-new-empty": {
+          stepCount: 0,
+          status: "CASCADE_RUN_STATUS_IDLE",
+        },
+      },
+    });
+
+    expect(await discoverOwnerInstance("c-new-empty", [hubLS], false)).toBe(
+      hubLS,
+    );
+    expect(conversationInstanceAffinity.get("c-new-empty")).toBe(hubLS);
   });
 
   it("picks RUNNING LS even with lower stepCount (readOnly=true)", async () => {
@@ -219,6 +297,7 @@ describe("resolveAndCall write-path safety (mutation misrouting prevention)", ()
   beforeEach(() => {
     vi.clearAllMocks();
     conversationAffinity.clear();
+    conversationInstanceAffinity.clear();
   });
 
   it("rejects mutations when conversation has no workspace metadata (warm-up loaded)", async () => {
@@ -255,6 +334,61 @@ describe("resolveAndCall write-path safety (mutation misrouting prevention)", ()
         false,
       ),
     ).rejects.toThrow("not found on any Language Server");
+  });
+
+  it("allows mutations through a single unscoped hub LS with workspace metadata", async () => {
+    const hubLS = makeInstance({ pid: 72, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+
+    mockRpcCall.mockImplementation(async (method: string) => {
+      if (method === "GetAllCascadeTrajectories") {
+        return {
+          trajectorySummaries: {
+            "cascade-hub": {
+              stepCount: 50,
+              status: "CASCADE_RUN_STATUS_IDLE",
+              workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/proj" }],
+            },
+          },
+        };
+      }
+      return { ok: true };
+    });
+
+    await expect(
+      resolveAndCall(
+        "SendUserCascadeMessage",
+        "cascade-hub",
+        { cascadeId: "cascade-hub", items: [] },
+        undefined,
+        false,
+      ),
+    ).resolves.toMatchObject({ data: { ok: true }, instance: hubLS });
+  });
+
+  it("uses cached unscoped hub ownership for follow-up writes after StartCascade", async () => {
+    const hubLS = makeInstance({ pid: 73, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+    conversationInstanceAffinity.set("new-cascade", hubLS);
+
+    mockRpcCall.mockResolvedValue({ ok: true });
+
+    await expect(
+      resolveAndCall(
+        "SendUserCascadeMessage",
+        "new-cascade",
+        { cascadeId: "new-cascade", items: [] },
+        undefined,
+        false,
+      ),
+    ).resolves.toMatchObject({ data: { ok: true }, instance: hubLS });
+
+    expect(mockRpcCall).toHaveBeenCalledTimes(1);
+    expect(mockRpcCall).toHaveBeenCalledWith(
+      "SendUserCascadeMessage",
+      { cascadeId: "new-cascade", items: [] },
+      hubLS,
+    );
   });
 
   it("allows reads for the same conversation that rejects writes", async () => {

--- a/packages/proxy/src/__tests__/workspaces-route.test.ts
+++ b/packages/proxy/src/__tests__/workspaces-route.test.ts
@@ -1,0 +1,115 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LSInstance } from "../discovery.js";
+
+const mockGetInstances = vi.fn<() => Promise<LSInstance[]>>();
+const mockRpcCall = vi.fn<
+  (method: string, body: unknown, inst: LSInstance) => Promise<unknown>
+>();
+
+vi.mock("../routing.js", () => ({
+  discovery: { getInstances: mockGetInstances },
+  rpc: { call: mockRpcCall },
+}));
+
+const { registerWorkspaceRoutes } = await import("../routes/workspaces.js");
+
+const makeInstance = (overrides: Partial<LSInstance> = {}): LSInstance => ({
+  pid: 1000 + Math.floor(Math.random() * 9000),
+  httpsPort: 9000 + Math.floor(Math.random() * 1000),
+  httpPort: 0,
+  lspPort: 0,
+  csrfToken: "test-csrf",
+  source: "daemon" as const,
+  ...overrides,
+});
+
+function app() {
+  const hono = new Hono();
+  registerWorkspaceRoutes(hono);
+  return hono;
+}
+
+describe("GET /api/workspaces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to conversation metadata when GetWorkspaceInfos has no workspaceInfos", async () => {
+    const hubLS = makeInstance({ pid: 1, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+    mockRpcCall.mockImplementation(async (method: string) => {
+      if (method === "GetWorkspaceInfos") {
+        return {
+          homeDirPath: "C:/Users/deepk",
+          homeDirUri: "file:///C:/Users/deepk",
+          geminiDirUri: "file:///C:/Users/deepk/.gemini",
+        };
+      }
+      if (method === "GetAllCascadeTrajectories") {
+        return {
+          trajectorySummaries: {
+            "c-hub": {
+              workspaces: [
+                {
+                  workspaceFolderAbsoluteUri: "file:///C:/Users/deepk/porta",
+                  gitRootAbsoluteUri: "file:///C:/Users/deepk/porta",
+                },
+              ],
+            },
+          },
+        };
+      }
+      return {};
+    });
+
+    const res = await app().request("/api/workspaces");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.workspaceInfos).toEqual([
+      {
+        workspaceUri: "file:///C:/Users/deepk/porta",
+        gitRootUri: "file:///C:/Users/deepk/porta",
+      },
+    ]);
+  });
+
+  it("keeps GetWorkspaceInfos results and deduplicates conversation fallback workspaces", async () => {
+    const ls = makeInstance({ pid: 2, workspaceId: "file_home_user_porta" });
+    mockGetInstances.mockResolvedValue([ls]);
+    mockRpcCall.mockImplementation(async (method: string) => {
+      if (method === "GetWorkspaceInfos") {
+        return {
+          workspaceInfos: [
+            {
+              workspaceUri: "file:///home/user/porta",
+              gitRootUri: "file:///home/user/porta",
+            },
+          ],
+        };
+      }
+      if (method === "GetAllCascadeTrajectories") {
+        return {
+          trajectorySummaries: {
+            "c1": {
+              workspaces: [
+                {
+                  workspaceFolderAbsoluteUri: "file:///home/user/porta",
+                  gitRootAbsoluteUri: "file:///home/user/porta",
+                },
+              ],
+            },
+          },
+        };
+      }
+      return {};
+    });
+
+    const res = await app().request("/api/workspaces");
+    const body = await res.json();
+
+    expect(body.workspaceInfos).toHaveLength(1);
+    expect(body.workspaceInfos[0].workspaceUri).toBe("file:///home/user/porta");
+  });
+});

--- a/packages/proxy/src/metadata.ts
+++ b/packages/proxy/src/metadata.ts
@@ -6,6 +6,16 @@ import { readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
+export interface ConversationWorkspaceMetadata {
+  workspaceFolderAbsoluteUri?: string;
+  gitRootAbsoluteUri?: string;
+  repository?: {
+    computedName?: string;
+    gitOriginUrl?: string;
+  };
+  branchName?: string;
+}
+
 const CONVERSATIONS_DIR = join(
   homedir(),
   ".gemini",
@@ -53,4 +63,79 @@ export async function scanDiskConversations(): Promise<
   } catch {
     return [];
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function workspaceArray(value: unknown): ConversationWorkspaceMetadata[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRecord).map((workspace) => ({
+    ...(typeof workspace.workspaceFolderAbsoluteUri === "string"
+      ? { workspaceFolderAbsoluteUri: workspace.workspaceFolderAbsoluteUri }
+      : {}),
+    ...(typeof workspace.gitRootAbsoluteUri === "string"
+      ? { gitRootAbsoluteUri: workspace.gitRootAbsoluteUri }
+      : {}),
+    ...(isRecord(workspace.repository)
+      ? {
+          repository: {
+            ...(typeof workspace.repository.computedName === "string"
+              ? { computedName: workspace.repository.computedName }
+              : {}),
+            ...(typeof workspace.repository.gitOriginUrl === "string"
+              ? { gitOriginUrl: workspace.repository.gitOriginUrl }
+              : {}),
+          },
+        }
+      : {}),
+    ...(typeof workspace.branchName === "string"
+      ? { branchName: workspace.branchName }
+      : {}),
+  }));
+}
+
+/**
+ * Extract workspace metadata from a conversation summary.
+ *
+ * Antigravity 1.x exposed this at `summary.workspaces`. Antigravity 2.x still
+ * exposes that for loaded conversations, but also mirrors it under
+ * `summary.trajectoryMetadata.workspaces` and may only expose URI strings in
+ * `summary.trajectoryMetadata.workspaceUris`.
+ */
+export function extractConversationWorkspaces(
+  summary: unknown,
+): ConversationWorkspaceMetadata[] {
+  if (!isRecord(summary)) return [];
+
+  const topLevel = workspaceArray(summary.workspaces);
+  if (topLevel.length > 0) return topLevel;
+
+  const trajectoryMetadata = summary.trajectoryMetadata;
+  if (!isRecord(trajectoryMetadata)) return [];
+
+  const metadataWorkspaces = workspaceArray(trajectoryMetadata.workspaces);
+  if (metadataWorkspaces.length > 0) return metadataWorkspaces;
+
+  if (!Array.isArray(trajectoryMetadata.workspaceUris)) return [];
+  return trajectoryMetadata.workspaceUris
+    .filter((uri): uri is string => typeof uri === "string")
+    .map((uri) => ({ workspaceFolderAbsoluteUri: uri }));
+}
+
+export function getPrimaryWorkspaceUri(summary: unknown): string | undefined {
+  return extractConversationWorkspaces(summary)[0]?.workspaceFolderAbsoluteUri;
+}
+
+export function withNormalizedConversationWorkspaces<T extends Record<string, unknown>>(
+  summary: T,
+): T {
+  if (Array.isArray(summary.workspaces) && summary.workspaces.length > 0) {
+    return summary;
+  }
+
+  const workspaces = extractConversationWorkspaces(summary);
+  if (workspaces.length === 0) return summary;
+  return { ...summary, workspaces };
 }

--- a/packages/proxy/src/platform/shared.ts
+++ b/packages/proxy/src/platform/shared.ts
@@ -188,13 +188,18 @@ export function parseNetstatPorts(output: string, pid: number): number[] {
 
   for (const rawLine of output.split("\n")) {
     const line = rawLine.trim();
-    if (!line || !line.includes("LISTENING")) continue;
+    if (!line) continue;
 
     const columns = line.split(/\s+/);
     if (columns.length < 5) continue;
 
     const rowPid = parseInt(columns[columns.length - 1], 10);
     if (rowPid !== pid) continue;
+
+    const remoteAddress = columns[2];
+    const isListening =
+      remoteAddress.endsWith(":0") || remoteAddress.endsWith(":*");
+    if (!isListening) continue;
 
     const localAddress = columns[1];
     const match = localAddress.match(/:(\d+)$/);

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -8,12 +8,19 @@ import {
   discovery,
   rpc,
   conversationAffinity,
+  conversationInstanceAffinity,
   uriToWorkspaceId,
   normalizeWorkspaceId,
   rpcForConversation,
   getStepCount,
 } from "../routing.js";
-import { getMetadata, scanDiskConversations } from "../metadata.js";
+import {
+  extractConversationWorkspaces,
+  getMetadata,
+  getPrimaryWorkspaceUri,
+  scanDiskConversations,
+  withNormalizedConversationWorkspaces,
+} from "../metadata.js";
 import { handleRPCError } from "../errors.js";
 import { runConversationMutation } from "../conversation-mutations.js";
 import {
@@ -35,6 +42,55 @@ const warmedAt = new Map<string, number>();
  *  This handles LS restarts (conversations fall out of memory) and
  *  transient failures without manual intervention. */
 const WARM_TTL_MS = 60_000;
+
+function requestedWorkspaceUris(body: Record<string, unknown>): string[] {
+  if (!Array.isArray(body.workspaceUris)) return [];
+  return body.workspaceUris.filter(
+    (uri): uri is string => typeof uri === "string" && uri.length > 0,
+  );
+}
+
+async function discoverSingleWorkspaceUri(
+  instances: LSInstance[],
+): Promise<string | undefined> {
+  const byWorkspaceId = new Map<string, string>();
+  const addUri = (uri: string | undefined) => {
+    if (!uri) return;
+    byWorkspaceId.set(normalizeWorkspaceId(uriToWorkspaceId(uri)), uri);
+  };
+
+  await Promise.allSettled(
+    instances.map(async (inst) => {
+      try {
+        const data = (await rpc.call("GetWorkspaceInfos", {}, inst)) as {
+          workspaceInfos?: { workspaceUri?: string }[];
+        };
+        for (const info of data.workspaceInfos ?? []) addUri(info.workspaceUri);
+      } catch {
+        // Fallback below can still recover workspace metadata from summaries.
+      }
+    }),
+  );
+
+  await Promise.allSettled(
+    instances.map(async (inst) => {
+      try {
+        const data = await rpc.call<{
+          trajectorySummaries?: Record<string, Record<string, unknown>>;
+        }>("GetAllCascadeTrajectories", {}, inst);
+        for (const summary of Object.values(data.trajectorySummaries ?? {})) {
+          for (const workspace of extractConversationWorkspaces(summary)) {
+            addUri(workspace.workspaceFolderAbsoluteUri);
+          }
+        }
+      } catch {
+        // If summaries are unavailable, keep whatever GetWorkspaceInfos found.
+      }
+    }),
+  );
+
+  return byWorkspaceId.size === 1 ? [...byWorkspaceId.values()][0] : undefined;
+}
 
 /**
  * Fire-and-forget: touch each disk-only conversation on every LS so the LS
@@ -113,7 +169,6 @@ export function registerConversationRoutes(app: Hono): void {
     try {
       const instances = await discovery.getInstances();
       const merged: Record<string, Record<string, unknown>> = {};
-      const ownerMap = new Map<string, LSInstance>();
 
       // Build normalized set of workspaceIds served by running LS instances.
       // Normalization handles format differences between CLI --workspace_id
@@ -133,12 +188,22 @@ export function registerConversationRoutes(app: Hono): void {
             }>("GetAllCascadeTrajectories", {}, inst);
             const summaries = data.trajectorySummaries ?? {};
             for (const [id, summary] of Object.entries(summaries)) {
-              // Skip conversations whose workspace isn't served by any running LS
-              const workspaces = summary.workspaces as
-                | { workspaceFolderAbsoluteUri?: string }[]
-                | undefined;
-              const wsUri = workspaces?.[0]?.workspaceFolderAbsoluteUri;
-              if (wsUri && !knownWsIds.has(normalizeWorkspaceId(uriToWorkspaceId(wsUri)))) continue;
+              const normalizedSummary =
+                withNormalizedConversationWorkspaces(summary);
+              const wsUri = getPrimaryWorkspaceUri(normalizedSummary);
+
+              // Skip conversations whose workspace isn't served by any scoped
+              // running LS. Antigravity 2.x exposes a hub LS with no
+              // workspaceId; in that mode GetWorkspaceInfos has no
+              // workspaceInfos, but GetAllCascadeTrajectories still contains
+              // conversation workspace metadata. Such unscoped LS results must
+              // pass through.
+              if (
+                inst.workspaceId &&
+                wsUri &&
+                !knownWsIds.has(normalizeWorkspaceId(uriToWorkspaceId(wsUri)))
+              )
+                continue;
 
               // NOTE: We intentionally do NOT inject the LS's workspace URI
               // into conversations that lack one. With warm-up loading .pb
@@ -148,11 +213,10 @@ export function registerConversationRoutes(app: Hono): void {
               // returns it with genuine metadata on the next poll cycle.
 
               const existing = merged[id];
-              const newCount = (summary.stepCount as number) ?? 0;
+              const newCount = (normalizedSummary.stepCount as number) ?? 0;
               const oldCount = (existing?.stepCount as number) ?? -1;
               if (!existing || newCount > oldCount) {
-                merged[id] = summary;
-                ownerMap.set(id, inst);
+                merged[id] = normalizedSummary;
               }
             }
           } catch {
@@ -163,15 +227,12 @@ export function registerConversationRoutes(app: Hono): void {
 
       // Update affinity cache from merged results
       for (const [id, summary] of Object.entries(merged)) {
-        const workspaces = summary.workspaces as
-          | { workspaceFolderAbsoluteUri?: string }[]
-          | undefined;
-        const wsUri = workspaces?.[0]?.workspaceFolderAbsoluteUri;
+        const wsUri = getPrimaryWorkspaceUri(summary);
         if (wsUri) {
           conversationAffinity.set(id, uriToWorkspaceId(wsUri));
         }
-        // NOTE: We intentionally do NOT learn affinity from the ownerMap
-        // when the conversation has no workspace metadata. With warm-up,
+        // NOTE: We intentionally do NOT learn affinity from the LS that returned
+        // the summary when the conversation has no workspace metadata. With warm-up,
         // the owning LS is not necessarily the one that returned the summary.
         // Affinity is only learned from genuine workspace metadata in the
         // conversation itself — either from the .pb or from the LS that
@@ -348,20 +409,31 @@ export function registerConversationRoutes(app: Hono): void {
 
   app.post("/api/conversations", async (c) => {
     try {
-      const body = await c.req.json().catch(() => ({}));
+      const body = ((await c.req.json().catch(() => ({}))) ?? {}) as Record<
+        string,
+        unknown
+      >;
       const metadata = await getMetadata(!!body.fileAccessGranted);
 
-      let workspaceUri: string | undefined = body.workspaceFolderAbsoluteUri;
+      const bodyWorkspaceUris = requestedWorkspaceUris(body);
+      let workspaceUri: string | undefined =
+        typeof body.workspaceFolderAbsoluteUri === "string"
+          ? body.workspaceFolderAbsoluteUri
+          : bodyWorkspaceUris[0];
+      const instances = await discovery.getInstances();
 
       // Resolve which LS instance to use based on workspace URI
       let targetInstance: LSInstance | undefined;
       if (workspaceUri) {
         const wsId = normalizeWorkspaceId(uriToWorkspaceId(workspaceUri));
-        const instances = await discovery.getInstances();
         targetInstance =
           instances.find(
             (i) => i.workspaceId && normalizeWorkspaceId(i.workspaceId) === wsId,
           ) ?? undefined;
+        targetInstance ??=
+          instances.filter((i) => !i.workspaceId).length === 1
+            ? instances.find((i) => !i.workspaceId)
+            : undefined;
 
         // Workspace was explicitly requested but no LS owns it — fail clearly
         if (!targetInstance) {
@@ -376,27 +448,30 @@ export function registerConversationRoutes(app: Hono): void {
         }
       } else {
         // No workspace specified — pick first available LS and auto-inject
-        targetInstance = (await discovery.getInstance()) ?? undefined;
-        try {
-          const wsInfos = (await rpc.call(
-            "GetWorkspaceInfos",
-            {},
-            targetInstance,
-          )) as {
-            workspaceInfos?: { workspaceUri: string }[];
-          };
-          workspaceUri = wsInfos.workspaceInfos?.[0]?.workspaceUri;
-        } catch {
-          // best-effort — proceed without workspace
-        }
+        targetInstance = instances[0];
+        workspaceUri = await discoverSingleWorkspaceUri(instances);
       }
+
+      const startWorkspaceUris =
+        bodyWorkspaceUris.length > 0
+          ? bodyWorkspaceUris
+          : workspaceUri
+            ? [workspaceUri]
+            : [];
 
       const data = await rpc.call(
         "StartCascade",
         {
           ...body,
           metadata,
+          source:
+            typeof body.source === "string"
+              ? body.source
+              : "CORTEX_TRAJECTORY_SOURCE_CASCADE_CLIENT",
           ...(workspaceUri ? { workspaceFolderAbsoluteUri: workspaceUri } : {}),
+          ...(startWorkspaceUris.length > 0
+            ? { workspaceUris: startWorkspaceUris }
+            : {}),
         },
         targetInstance,
       );
@@ -405,8 +480,13 @@ export function registerConversationRoutes(app: Hono): void {
       const newId = (data as Record<string, unknown>)?.cascadeId as
         | string
         | undefined;
-      if (newId && targetInstance?.workspaceId) {
+      if (newId && workspaceUri) {
+        conversationAffinity.set(newId, uriToWorkspaceId(workspaceUri));
+      } else if (newId && targetInstance?.workspaceId) {
         conversationAffinity.set(newId, targetInstance.workspaceId);
+      }
+      if (newId && targetInstance && !targetInstance.workspaceId) {
+        conversationInstanceAffinity.set(newId, targetInstance);
       }
 
       // Signal WS connections for this conversation to enter ACTIVE state

--- a/packages/proxy/src/routes/workspaces.ts
+++ b/packages/proxy/src/routes/workspaces.ts
@@ -5,12 +5,16 @@
 import type { Hono } from "hono";
 import { discovery, rpc } from "../routing.js";
 import { handleRPCError } from "../errors.js";
+import { extractConversationWorkspaces } from "../metadata.js";
 
 export function registerWorkspaceRoutes(app: Hono): void {
   app.get("/api/workspaces", async (c) => {
     try {
       const instances = await discovery.getInstances();
-      const allInfos: { workspaceUri: string; gitRootUri?: string }[] = [];
+      const workspaceMap = new Map<
+        string,
+        { workspaceUri: string; gitRootUri?: string }
+      >();
       let homeDirPath = "";
       let homeDirUri = "";
 
@@ -24,14 +28,44 @@ export function registerWorkspaceRoutes(app: Hono): void {
             };
             if (data.homeDirPath) homeDirPath = data.homeDirPath;
             if (data.homeDirUri) homeDirUri = data.homeDirUri;
-            if (data.workspaceInfos) allInfos.push(...data.workspaceInfos);
+            for (const info of data.workspaceInfos ?? []) {
+              workspaceMap.set(info.workspaceUri, info);
+            }
           } catch {
             // Skip unreachable instances
           }
         }),
       );
 
-      return c.json({ homeDirPath, homeDirUri, workspaceInfos: allInfos });
+      await Promise.allSettled(
+        instances.map(async (inst) => {
+          try {
+            const data = await rpc.call<{
+              trajectorySummaries?: Record<string, Record<string, unknown>>;
+            }>("GetAllCascadeTrajectories", {}, inst);
+            for (const summary of Object.values(data.trajectorySummaries ?? {})) {
+              for (const workspace of extractConversationWorkspaces(summary)) {
+                const workspaceUri = workspace.workspaceFolderAbsoluteUri;
+                if (!workspaceUri || workspaceMap.has(workspaceUri)) continue;
+                workspaceMap.set(workspaceUri, {
+                  workspaceUri,
+                  ...(workspace.gitRootAbsoluteUri
+                    ? { gitRootUri: workspace.gitRootAbsoluteUri }
+                    : {}),
+                });
+              }
+            }
+          } catch {
+            // Conversation summaries are a fallback for Antigravity 2.x hub LS.
+          }
+        }),
+      );
+
+      return c.json({
+        homeDirPath,
+        homeDirUri,
+        workspaceInfos: Array.from(workspaceMap.values()),
+      });
     } catch (err) {
       return handleRPCError(c, err);
     }

--- a/packages/proxy/src/routing.ts
+++ b/packages/proxy/src/routing.ts
@@ -6,6 +6,7 @@
  */
 
 import { LSDiscovery, type LSInstance } from "./discovery.js";
+import { getPrimaryWorkspaceUri } from "./metadata.js";
 import { RPCClient, RPCError } from "./rpc.js";
 
 // Module-scoped singletons — shared by all route modules
@@ -18,6 +19,7 @@ export const rpc = new RPCClient(discovery);
  * and used to route RPC calls to the correct LS instance.
  */
 export const conversationAffinity = new Map<string, string>(); // cascadeId → workspaceId
+export const conversationInstanceAffinity = new Map<string, LSInstance>(); // cascadeId → unscoped hub LS
 
 /** Convert a workspace URI to the LS workspaceId format. */
 export function uriToWorkspaceId(uri: string): string {
@@ -109,7 +111,8 @@ export async function discoverOwnerInstance(
             {
               stepCount?: number;
               status?: string;
-              workspaces?: { workspaceFolderAbsoluteUri?: string }[];
+              trajectoryMetadata?: unknown;
+              workspaces?: unknown[];
             }
           >;
         }>("GetAllCascadeTrajectories", {}, inst);
@@ -119,7 +122,7 @@ export async function discoverOwnerInstance(
           inst,
           stepCount: summary.stepCount ?? 0,
           status: (summary.status as string) ?? "",
-          wsUri: summary.workspaces?.[0]?.workspaceFolderAbsoluteUri,
+          wsUri: getPrimaryWorkspaceUri(summary),
         });
       } catch {
         // Skip unreachable instances
@@ -140,9 +143,32 @@ export async function discoverOwnerInstance(
     const wsOwners = candidates.filter(
       (c) => c.inst.workspaceId && normalizeWorkspaceId(c.inst.workspaceId) === normalWsId,
     );
-    if (wsOwners.length === 0) return null;
-    wsOwners.sort((a, b) => b.stepCount - a.stepCount);
-    return wsOwners[0].inst;
+    if (wsOwners.length > 0) {
+      wsOwners.sort((a, b) => b.stepCount - a.stepCount);
+      return wsOwners[0].inst;
+    }
+
+    // Antigravity 2.x can expose a standalone hub LS without a workspaceId.
+    // When exactly one unscoped LS reports this workspace-backed conversation,
+    // that LS is the only concrete owner signal available and is safe for both
+    // reads and writes. If multiple unscoped LSes report it, only reads may use
+    // the heuristic ranking below; writes stay conservative.
+    const unscopedOwners = candidates.filter((c) => !c.inst.workspaceId);
+    if (unscopedOwners.length === 1) {
+      conversationInstanceAffinity.set(cascadeId, unscopedOwners[0].inst);
+      return unscopedOwners[0].inst;
+    }
+    if (readOnly && unscopedOwners.length > 1) {
+      unscopedOwners.sort((a, b) => {
+        const aRunning = a.status === RUNNING_STATUS ? 1 : 0;
+        const bRunning = b.status === RUNNING_STATUS ? 1 : 0;
+        if (aRunning !== bRunning) return bRunning - aRunning;
+        return b.stepCount - a.stepCount;
+      });
+      conversationInstanceAffinity.set(cascadeId, unscopedOwners[0].inst);
+      return unscopedOwners[0].inst;
+    }
+    return null;
   }
 
   // No workspace metadata.
@@ -156,6 +182,15 @@ export async function discoverOwnerInstance(
   // A RUNNING LS is definitively the active owner (only one LS can execute
   // a conversation at a time). Affinity is NOT learned because we don't
   // know the workspace URI.
+  if (
+    !readOnly &&
+    candidates.length === 1 &&
+    !candidates[0].inst.workspaceId
+  ) {
+    conversationInstanceAffinity.set(cascadeId, candidates[0].inst);
+    return candidates[0].inst;
+  }
+
   if (!readOnly) return null;
 
   candidates.sort((a, b) => {
@@ -196,6 +231,32 @@ export async function resolveAndCall<T>(
   const instances = await discovery.getInstances();
   if (instances.length === 0) {
     throw new RPCError("No LS instances available", "unavailable");
+  }
+
+  const cachedInstance = conversationInstanceAffinity.get(cascadeId);
+  if (cachedInstance) {
+    const current = instances.find(
+      (i) =>
+        i.pid === cachedInstance.pid &&
+        i.httpsPort === cachedInstance.httpsPort,
+    );
+    if (current) {
+      try {
+        const data = await rpc.call<T>(method, body, current);
+        return { data, instance: current };
+      } catch (err) {
+        if (
+          err instanceof RPCError &&
+          (err.code === "unavailable" || err.code === "not_found")
+        ) {
+          conversationInstanceAffinity.delete(cascadeId);
+        } else {
+          throw err;
+        }
+      }
+    } else {
+      conversationInstanceAffinity.delete(cascadeId);
+    }
   }
 
   // Try the affinity LS first

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -3211,9 +3211,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3969,9 +3969,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.13)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 4.0.18(@types/node@22.19.13)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.47.1)(tsx@4.21.0)
 
   packages/web:
     dependencies:
@@ -77,7 +77,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react-swc':
         specifier: ^4.2.2
-        version: 4.2.3(vite@7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0))
+        version: 4.2.3(vite@7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0))
       eslint:
         specifier: ^9.39.1
         version: 9.39.3
@@ -107,13 +107,13 @@ importers:
         version: 8.56.1(eslint@9.39.3)(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0)
       vite-plugin-pwa:
         specifier: ^1.2.0
-        version: 1.2.0(vite@7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
+        version: 1.2.0(vite@7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.0)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@24.11.0)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.46.1)(tsx@4.21.0)
+        version: 4.0.18(@types/node@24.11.0)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.47.1)(tsx@4.21.0)
 
 packages:
 
@@ -147,6 +147,10 @@ packages:
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/core@7.29.0':
     resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
     engines: {node: '>=6.9.0'}
@@ -163,8 +167,8 @@ packages:
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.28.6':
-    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+  '@babel/helper-create-class-features-plugin@7.29.3':
+    resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -261,6 +265,12 @@ packages:
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3':
+    resolution: {integrity: sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -451,8 +461,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -607,8 +617,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.29.2':
-    resolution: {integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==}
+  '@babel/preset-env@7.29.5':
+    resolution: {integrity: sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1223,6 +1233,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1363,8 +1376,8 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1442,21 +1455,31 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  baseline-browser-mapping@2.10.31:
+    resolution: {integrity: sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.14:
+    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
 
-  brace-expansion@2.0.3:
-    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1467,8 +1490,8 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
-  call-bind@1.0.8:
-    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
     engines: {node: '>= 0.4'}
 
   call-bound@1.0.4:
@@ -1481,6 +1504,9 @@ packages:
 
   caniuse-lite@1.0.30001775:
     resolution: {integrity: sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -1604,6 +1630,9 @@ packages:
   electron-to-chromium@1.5.302:
     resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
 
+  electron-to-chromium@1.5.357:
+    resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
+
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
@@ -1612,8 +1641,8 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
-  es-abstract@1.24.1:
-    resolution: {integrity: sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==}
+  es-abstract@1.24.2:
+    resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
     engines: {node: '>= 0.4'}
 
   es-define-property@1.0.1:
@@ -1731,8 +1760,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1870,8 +1899,8 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
   hermes-estree@0.25.1:
@@ -1943,8 +1972,8 @@ packages:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-data-view@1.0.2:
@@ -2090,8 +2119,8 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
   jsonpointer@5.0.1:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
@@ -2121,15 +2150,15 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
+  lru-cache@11.4.0:
+    resolution: {integrity: sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -2165,6 +2194,10 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -2189,6 +2222,9 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2350,8 +2386,8 @@ packages:
   regjsgen@0.8.0:
     resolution: {integrity: sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==}
 
-  regjsparser@0.13.0:
-    resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
+  regjsparser@0.13.1:
+    resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
   require-from-string@2.0.2:
@@ -2365,8 +2401,8 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  resolve@1.22.11:
-    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
     hasBin: true
 
@@ -2380,8 +2416,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  safe-array-concat@1.1.3:
-    resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
+  safe-array-concat@1.1.4:
+    resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
   safe-buffer@5.2.1:
@@ -2441,8 +2477,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  side-channel-list@1.0.0:
-    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
     engines: {node: '>= 0.4'}
 
   side-channel-map@1.0.1:
@@ -2464,8 +2500,8 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  smob@1.6.1:
-    resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
+  smob@1.6.2:
+    resolution: {integrity: sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==}
     engines: {node: '>=20.0.0'}
 
   source-map-js@1.2.1:
@@ -2549,8 +2585,8 @@ packages:
     resolution: {integrity: sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==}
     engines: {node: '>=10'}
 
-  terser@5.46.1:
-    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
+  terser@5.47.1:
+    resolution: {integrity: sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2929,9 +2965,9 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@apideck/better-ajv-errors@0.3.7(ajv@8.18.0)':
+  '@apideck/better-ajv-errors@0.3.7(ajv@8.20.0)':
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       jsonpointer: 5.0.1
       leven: 3.1.0
 
@@ -2960,6 +2996,8 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/compat-data@7.29.0': {}
+
+  '@babel/compat-data@7.29.3': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -3001,7 +3039,7 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
@@ -3028,7 +3066,7 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
       lodash.debounce: 4.0.8
-      resolve: 1.22.11
+      resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
 
@@ -3129,6 +3167,14 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -3202,7 +3248,7 @@ snapshots:
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3210,7 +3256,7 @@ snapshots:
   '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3334,7 +3380,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -3413,7 +3459,7 @@ snapshots:
   '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3422,7 +3468,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -3499,9 +3545,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
@@ -3509,6 +3555,7 @@ snapshots:
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
@@ -3540,7 +3587,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -3819,7 +3866,7 @@ snapshots:
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
-      resolve: 1.22.11
+      resolve: 1.22.12
     optionalDependencies:
       rollup: 2.80.0
 
@@ -3832,8 +3879,8 @@ snapshots:
   '@rollup/plugin-terser@0.4.4(rollup@2.80.0)':
     dependencies:
       serialize-javascript: 6.0.2
-      smob: 1.6.1
-      terser: 5.46.1
+      smob: 1.6.2
+      terser: 5.47.1
     optionalDependencies:
       rollup: 2.80.0
 
@@ -3846,7 +3893,7 @@ snapshots:
 
   '@rollup/pluginutils@5.3.0(rollup@2.80.0)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
@@ -4035,6 +4082,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/estree@1.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/node@22.19.13':
@@ -4154,11 +4203,11 @@ snapshots:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
 
-  '@vitejs/plugin-react-swc@4.2.3(vite@7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react-swc@4.2.3(vite@7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
       '@swc/core': 1.15.18
-      vite: 7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4171,21 +4220,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(terser@5.46.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(terser@5.47.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.13)(terser@5.46.1)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.13)(terser@5.47.1)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -4224,10 +4273,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4255,9 +4304,9 @@ snapshots:
   arraybuffer.prototype.slice@1.0.4:
     dependencies:
       array-buffer-byte-length: 1.0.2
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
@@ -4276,7 +4325,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -4304,20 +4353,22 @@ snapshots:
 
   baseline-browser-mapping@2.10.0: {}
 
+  baseline-browser-mapping@2.10.31: {}
+
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.14:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.3:
+  brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4329,6 +4380,14 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.31
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.357
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
   buffer-from@1.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -4336,7 +4395,7 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
-  call-bind@1.0.8:
+  call-bind@1.0.9:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-define-property: 1.0.1
@@ -4351,6 +4410,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001775: {}
+
+  caniuse-lite@1.0.30001793: {}
 
   chai@6.2.2: {}
 
@@ -4377,7 +4438,7 @@ snapshots:
 
   core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4468,16 +4529,18 @@ snapshots:
 
   electron-to-chromium@1.5.302: {}
 
+  electron-to-chromium@1.5.357: {}
+
   entities@6.0.1: {}
 
   entities@7.0.1: {}
 
-  es-abstract@1.24.1:
+  es-abstract@1.24.2:
     dependencies:
       array-buffer-byte-length: 1.0.2
       arraybuffer.prototype.slice: 1.0.4
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       data-view-buffer: 1.0.2
       data-view-byte-length: 1.0.2
@@ -4496,7 +4559,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -4514,7 +4577,7 @@ snapshots:
       object.assign: 4.1.7
       own-keys: 1.0.1
       regexp.prototype.flags: 1.5.4
-      safe-array-concat: 1.1.3
+      safe-array-concat: 1.1.4
       safe-push-apply: 1.0.0
       safe-regex-test: 1.1.0
       set-proto: 1.0.0
@@ -4544,7 +4607,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -4684,7 +4747,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -4723,7 +4786,7 @@ snapshots:
     dependencies:
       at-least-node: 1.0.0
       graceful-fs: 4.2.11
-      jsonfile: 6.2.0
+      jsonfile: 6.2.1
       universalify: 2.0.1
 
   fsevents@2.3.3:
@@ -4733,11 +4796,11 @@ snapshots:
 
   function.prototype.name@1.1.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.3
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -4756,7 +4819,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       math-intrinsics: 1.1.0
 
   get-own-enumerable-property-symbols@3.0.2: {}
@@ -4784,7 +4847,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
@@ -4832,7 +4895,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
+  hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
@@ -4882,12 +4945,12 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.3
       side-channel: 1.1.0
 
   is-array-buffer@3.0.5:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
@@ -4910,9 +4973,9 @@ snapshots:
 
   is-callable@1.2.7: {}
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-data-view@1.0.2:
     dependencies:
@@ -4963,7 +5026,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.3
 
   is-regexp@1.0.0: {}
 
@@ -5060,7 +5123,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsonfile@6.2.0:
+  jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
@@ -5089,11 +5152,11 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   lru-cache@11.2.6: {}
 
-  lru-cache@11.2.7: {}
+  lru-cache@11.4.0: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -5119,15 +5182,19 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.6
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.14
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.0.3
+      brace-expansion: 2.1.0
 
   minipass@7.1.3: {}
 
@@ -5139,13 +5206,15 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  node-releases@2.0.44: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
@@ -5195,7 +5264,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.7
+      lru-cache: 11.4.0
       minipass: 7.1.3
 
   pathe@2.0.3: {}
@@ -5264,9 +5333,9 @@ snapshots:
 
   reflect.getprototypeof@1.0.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -5281,7 +5350,7 @@ snapshots:
 
   regexp.prototype.flags@1.5.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-errors: 1.3.0
       get-proto: 1.0.1
@@ -5293,13 +5362,13 @@ snapshots:
       regenerate: 1.4.2
       regenerate-unicode-properties: 10.2.2
       regjsgen: 0.8.0
-      regjsparser: 0.13.0
+      regjsparser: 0.13.1
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.2.1
 
   regjsgen@0.8.0: {}
 
-  regjsparser@0.13.0:
+  regjsparser@0.13.1:
     dependencies:
       jsesc: 3.1.0
 
@@ -5309,9 +5378,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  resolve@1.22.11:
+  resolve@1.22.12:
     dependencies:
-      is-core-module: 2.16.1
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -5350,9 +5420,9 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
-  safe-array-concat@1.1.3:
+  safe-array-concat@1.1.4:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
@@ -5417,7 +5487,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  side-channel-list@1.0.0:
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -5441,7 +5511,7 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
-      side-channel-list: 1.0.0
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -5449,7 +5519,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  smob@1.6.1: {}
+  smob@1.6.2: {}
 
   source-map-js@1.2.1: {}
 
@@ -5477,10 +5547,10 @@ snapshots:
 
   string.prototype.matchall@4.0.12:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
       get-intrinsic: 1.3.0
@@ -5493,24 +5563,24 @@ snapshots:
 
   string.prototype.trim@1.2.10:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-data-property: 1.1.4
       define-properties: 1.2.1
-      es-abstract: 1.24.1
+      es-abstract: 1.24.2
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
 
   string.prototype.trimend@1.0.9:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
   string.prototype.trimstart@1.0.8:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
@@ -5545,7 +5615,7 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser@5.46.1:
+  terser@5.47.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
@@ -5606,7 +5676,7 @@ snapshots:
 
   typed-array-byte-length@1.0.3:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -5615,7 +5685,7 @@ snapshots:
   typed-array-byte-offset@1.0.4:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       has-proto: 1.2.0
@@ -5624,7 +5694,7 @@ snapshots:
 
   typed-array-length@1.0.7:
     dependencies:
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       for-each: 0.3.5
       gopd: 1.2.0
       is-typed-array: 1.1.15
@@ -5682,22 +5752,28 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
 
-  vite-plugin-pwa@1.2.0(vite@7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.0):
+  vite-plugin-pwa@1.2.0(vite@7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0))(workbox-build@7.4.0)(workbox-window@7.4.0):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.15
-      vite: 7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0)
       workbox-build: 7.4.0
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  vite@7.3.1(@types/node@22.19.13)(terser@5.46.1)(tsx@4.21.0):
+  vite@7.3.1(@types/node@22.19.13)(terser@5.47.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5708,10 +5784,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
       fsevents: 2.3.3
-      terser: 5.46.1
+      terser: 5.47.1
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0):
+  vite@7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5722,13 +5798,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.11.0
       fsevents: 2.3.3
-      terser: 5.46.1
+      terser: 5.47.1
       tsx: 4.21.0
 
-  vitest@4.0.18(@types/node@22.19.13)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.46.1)(tsx@4.21.0):
+  vitest@4.0.18(@types/node@22.19.13)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.47.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(terser@5.46.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(terser@5.47.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -5745,7 +5821,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.19.13)(terser@5.46.1)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.13)(terser@5.47.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.13
@@ -5764,10 +5840,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@24.11.0)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.46.1)(tsx@4.21.0):
+  vitest@4.0.18(@types/node@24.11.0)(happy-dom@20.8.9)(jsdom@28.1.0)(terser@5.47.1)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -5784,7 +5860,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@24.11.0)(terser@5.46.1)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(terser@5.47.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.11.0
@@ -5863,7 +5939,7 @@ snapshots:
   which-typed-array@1.1.20:
     dependencies:
       available-typed-arrays: 1.0.7
-      call-bind: 1.0.8
+      call-bind: 1.0.9
       call-bound: 1.0.4
       for-each: 0.3.5
       get-proto: 1.0.1
@@ -5892,21 +5968,21 @@ snapshots:
 
   workbox-build@7.4.0:
     dependencies:
-      '@apideck/better-ajv-errors': 0.3.7(ajv@8.18.0)
+      '@apideck/better-ajv-errors': 0.3.7(ajv@8.20.0)
       '@babel/core': 7.29.0
-      '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
+      '@babel/preset-env': 7.29.5(@babel/core@7.29.0)
       '@babel/runtime': 7.29.2
       '@rollup/plugin-babel': 5.3.1(@babel/core@7.29.0)(rollup@2.80.0)
       '@rollup/plugin-node-resolve': 15.3.1(rollup@2.80.0)
       '@rollup/plugin-replace': 2.4.2(rollup@2.80.0)
       '@rollup/plugin-terser': 0.4.4(rollup@2.80.0)
       '@surma/rollup-plugin-off-main-thread': 2.2.3
-      ajv: 8.18.0
+      ajv: 8.20.0
       common-tags: 1.8.2
       fast-json-stable-stringify: 2.1.0
       fs-extra: 9.1.0
       glob: 11.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       pretty-bytes: 5.6.0
       rollup: 2.80.0
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
## Summary

- release Antigravity 2.x workspace metadata compatibility fix for #56 via #57
- release localized Windows netstat discovery fix for #52 via #59
- bump root version, README badge, and CHANGELOG to v0.7.0

## Verification

- pnpm -r test
- pnpm -r build