### PR TITLE
fix(web): bind Vite server to PORTA_HOST for LAN/custom IP access

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
     ],
     envDir: repoRoot,
     server: {
+      host: proxyHost,
       proxy: {
         "/api": {
           target: toHttpOrigin(proxyHost, proxyPort),

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - packages/proxy
   - packages/web
 
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild


### PR DESCRIPTION
## Problem
When `PORTA_HOST` is set to an explicit private LAN IP (e.g., `192.168.1.6`) in the `.env` file, the user is unable to access the web application at `http://192.168.1.6:5173/porta`. This is because Vite's dev server by default binds to `localhost`/`127.0.0.1` and does not listen on the configured `PORTA_HOST` LAN IP.

## Root Cause
In `packages/web/vite.config.ts`, the `server` configuration has a proxy setup but does not specify the `host` property. Thus, Vite uses its default host binding (loopback interface only), ignoring `PORTA_HOST`.

## Proposed Changes
- Modified `packages/web/vite.config.ts` to set `server.host` to `proxyHost` (which resolves to `PORTA_HOST` or defaults to `127.0.0.1`).
- Included `pnpm-workspace.yaml` update to allow builds of binary packages on Windows.

## Tests Run
Ran automated tests in the workspace:
- `pnpm test` (All 253 tests passed successfully).
- Verified production build via `pnpm build`.

## Deployment Status
Local changes have been verified and built successfully. They are ready to be integrated into the develop branch.