### PR TITLE
Add browser notifications for run completion and approvals

### DIFF
--- a/packages/web/e2e/fixtures/appHarness.ts
+++ b/packages/web/e2e/fixtures/appHarness.ts
@@ -287,6 +287,13 @@ class CdpPage {
     );
   }
 
+  async grantPermissions(permissions: string[], origin: string) {
+    await this.connection.send("Browser.grantPermissions", {
+      permissions,
+      origin,
+    });
+  }
+
   async count(selector: string) {
     return this.evaluate<number>(
       `document.querySelectorAll(${JSON.stringify(selector)}).length`,

--- a/packages/web/e2e/fixtures/mockApiServer.ts
+++ b/packages/web/e2e/fixtures/mockApiServer.ts
@@ -8,6 +8,7 @@ interface ConversationState {
   createdTime: string;
   lastModifiedTime: string;
   summary: string;
+  status: string;
   workspaceUri: string;
   steps: unknown[];
 }
@@ -83,13 +84,57 @@ export class MockApiServer {
     this.nextConversationNumber = 1;
   }
 
+  createConversation(
+    id: string,
+    {
+      summary = "New Chat",
+      status = "CASCADE_RUN_STATUS_IDLE",
+      steps = [],
+    }: {
+      summary?: string;
+      status?: string;
+      steps?: unknown[];
+    } = {},
+  ) {
+    const createdTime = nowIso();
+    this.conversations.set(id, {
+      id,
+      createdTime,
+      lastModifiedTime: createdTime,
+      summary,
+      status,
+      workspaceUri: this.workspaceUri,
+      steps,
+    });
+  }
+
+  setConversationStatus(id: string, status: string) {
+    const conversation = this.conversations.get(id);
+    if (!conversation) {
+      throw new Error(`Conversation not found: ${id}`);
+    }
+
+    conversation.status = status;
+    conversation.lastModifiedTime = nowIso();
+  }
+
+  setConversationSteps(id: string, steps: unknown[]) {
+    const conversation = this.conversations.get(id);
+    if (!conversation) {
+      throw new Error(`Conversation not found: ${id}`);
+    }
+
+    conversation.steps = steps;
+    conversation.lastModifiedTime = nowIso();
+  }
+
   private conversationSummary(conversation: ConversationState) {
     return {
       summary: conversation.summary,
       stepCount: conversation.steps.length,
       lastModifiedTime: conversation.lastModifiedTime,
       trajectoryId: conversation.id,
-      status: "CASCADE_RUN_STATUS_IDLE",
+      status: conversation.status,
       createdTime: conversation.createdTime,
       workspaces: [
         {
@@ -186,6 +231,7 @@ export class MockApiServer {
           createdTime,
           lastModifiedTime: createdTime,
           summary: "New Chat",
+          status: "CASCADE_RUN_STATUS_IDLE",
           workspaceUri,
           steps: [],
         };

--- a/packages/web/e2e/notifications.e2e.test.ts
+++ b/packages/web/e2e/notifications.e2e.test.ts
@@ -1,0 +1,199 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { AppHarness } from "./fixtures/appHarness";
+
+const ORIGIN = "http://127.0.0.1:4173";
+
+const USER_STEP = {
+  type: "CORTEX_STEP_TYPE_USER_INPUT",
+  userInput: {
+    items: [{ text: "Notification check" }],
+  },
+};
+
+const ASSISTANT_STEP = {
+  type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+  plannerResponse: {
+    modifiedResponse: "I finished the requested notification check.",
+  },
+};
+
+function waitingCommandStep(command: string) {
+  return {
+    type: "CORTEX_STEP_TYPE_RUN_COMMAND",
+    status: "CORTEX_STEP_STATUS_WAITING",
+    metadata: {
+      sourceTrajectoryStepInfo: {
+        trajectoryId: "traj-notify",
+        stepIndex: 2,
+      },
+    },
+    runCommand: {
+      proposedCommandLine: command,
+    },
+  };
+}
+
+async function installNotificationRecorder(
+  page: Awaited<ReturnType<AppHarness["newPage"]>>,
+) {
+  await page.grantPermissions(["notifications"], ORIGIN);
+  await page.evaluate(`(() => {
+    const NativeNotification = window.Notification;
+    const notifications = [];
+
+    function RecordedNotification(title, options) {
+      notifications.push({
+        title,
+        body: options?.body ?? "",
+        tag: options?.tag ?? "",
+        permission: NativeNotification.permission,
+      });
+      return new NativeNotification(title, options);
+    }
+
+    Object.defineProperty(RecordedNotification, "permission", {
+      get: () => NativeNotification.permission,
+    });
+    RecordedNotification.requestPermission = async (callback) => {
+      const permission = NativeNotification.permission;
+      callback?.(permission);
+      return permission;
+    };
+
+    Object.defineProperty(window, "__portaNotifications", {
+      configurable: true,
+      value: notifications,
+    });
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: RecordedNotification,
+    });
+  })()`);
+}
+
+async function makePageNeedAttention(
+  page: Awaited<ReturnType<AppHarness["newPage"]>>,
+) {
+  await page.evaluate(`(() => {
+    Object.defineProperty(document, "hasFocus", {
+      configurable: true,
+      value: () => false,
+    });
+  })()`);
+}
+
+async function triggerResumeRefresh(
+  page: Awaited<ReturnType<AppHarness["newPage"]>>,
+) {
+  await page.evaluate(`window.dispatchEvent(new Event("focus"))`);
+}
+
+describe("browser notifications", () => {
+  let harness: AppHarness | undefined;
+  let page: Awaited<ReturnType<AppHarness["newPage"]>> | null = null;
+
+  beforeAll(async () => {
+    harness = await AppHarness.start();
+  });
+
+  afterAll(async () => {
+    await harness?.stop();
+  });
+
+  beforeEach(async () => {
+    harness!.api.reset();
+    page = await harness!.newPage();
+    await page.navigate(harness!.url("/"));
+    await page.evaluate(`localStorage.removeItem("porta:settings")`);
+  });
+
+  afterEach(async () => {
+    await page?.close();
+    page = null;
+  });
+
+  it("enables browser notifications from Settings", async () => {
+    const app = harness!;
+
+    await page!.navigate(app.url("/porta/settings"));
+    await installNotificationRecorder(page!);
+
+    await page!.click('input[aria-label="Browser Notifications"]');
+
+    await page!.waitFor(
+      `(() => {
+        const raw = localStorage.getItem("porta:settings");
+        return Boolean(raw && JSON.parse(raw).browserNotificationsEnabled === true);
+      })()`,
+      { timeoutMs: 5_000, description: "browser notification setting to save" },
+    );
+
+    expect(
+      await page!.evaluate<string>(
+        `document.querySelector(".settings-permission-status")?.textContent ?? ""`,
+      ),
+    ).toBe("On");
+  });
+
+  it("fires a browser notification for new command approval requests", async () => {
+    const app = harness!;
+    app.api.createConversation("conv-notify", {
+      summary: "Notification test",
+      steps: [USER_STEP],
+    });
+
+    await page!.navigate(app.url("/porta/settings"));
+    await installNotificationRecorder(page!);
+    await page!.click('input[aria-label="Browser Notifications"]');
+
+    await page!.navigate(app.url("/porta/conv-notify"));
+    await installNotificationRecorder(page!);
+    await page!.waitForText("Notification check");
+    await makePageNeedAttention(page!);
+
+    app.api.setConversationSteps("conv-notify", [
+      USER_STEP,
+      waitingCommandStep("pnpm test"),
+    ]);
+    await triggerResumeRefresh(page!);
+
+    await page!.waitFor(
+      `window.__portaNotifications?.some((notification) =>
+        notification.title === "Porta needs approval" &&
+        notification.body === "pnpm test" &&
+        notification.permission === "granted"
+      )`,
+      { timeoutMs: 10_000, description: "approval notification to fire" },
+    );
+  });
+
+  it("fires a browser notification when a running conversation becomes idle", async () => {
+    const app = harness!;
+    app.api.createConversation("conv-run", {
+      summary: "Run finished test",
+      status: "CASCADE_RUN_STATUS_RUNNING",
+      steps: [USER_STEP, ASSISTANT_STEP],
+    });
+
+    await page!.navigate(app.url("/porta/settings"));
+    await installNotificationRecorder(page!);
+    await page!.click('input[aria-label="Browser Notifications"]');
+
+    await page!.navigate(app.url("/porta/conv-run"));
+    await installNotificationRecorder(page!);
+    await page!.waitForText("Notification check");
+    await makePageNeedAttention(page!);
+
+    app.api.setConversationStatus("conv-run", "CASCADE_RUN_STATUS_IDLE");
+    await triggerResumeRefresh(page!);
+
+    await page!.waitFor(
+      `window.__portaNotifications?.some((notification) =>
+        notification.title === "Porta job finished" &&
+        notification.body === "I finished the requested notification check." &&
+        notification.permission === "granted"
+      )`,
+      { timeoutMs: 10_000, description: "run-finished notification to fire" },
+    );
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -293,6 +293,8 @@ function ChatView() {
             hardRefreshKey={hardRefreshKey}
             totalStepCount={activeConv?.summary.stepCount}
             isConversationRunning={isRunning}
+            browserNotificationsEnabled={settings.browserNotificationsEnabled}
+            conversationTitle={headerTitle}
             onSidebarRefresh={refresh}
           />
         ) : (

--- a/packages/web/src/__tests__/browserNotifications.test.ts
+++ b/packages/web/src/__tests__/browserNotifications.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getBrowserNotificationPermission,
+  requestBrowserNotificationPermission,
+  showBrowserNotification,
+} from "../utils/browserNotifications";
+
+class MockNotification {
+  static permission: NotificationPermission = "granted";
+  static requestPermission = vi.fn<() => Promise<NotificationPermission>>();
+  static created: MockNotification[] = [];
+
+  title: string;
+  options?: NotificationOptions;
+  onclick: (() => void) | null = null;
+  close = vi.fn();
+
+  constructor(title: string, options?: NotificationOptions) {
+    this.title = title;
+    this.options = options;
+    MockNotification.created.push(this);
+  }
+}
+
+function stubNotification(permission: NotificationPermission) {
+  MockNotification.permission = permission;
+  MockNotification.requestPermission.mockResolvedValue(permission);
+  MockNotification.created = [];
+
+  Object.defineProperty(window, "Notification", {
+    configurable: true,
+    value: MockNotification,
+  });
+}
+
+function stubAttentionNeeded(hidden: boolean, focused: boolean) {
+  Object.defineProperty(document, "hidden", {
+    configurable: true,
+    value: hidden,
+  });
+  Object.defineProperty(document, "hasFocus", {
+    configurable: true,
+    value: () => focused,
+  });
+}
+
+describe("browserNotifications", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    MockNotification.requestPermission.mockReset();
+    MockNotification.created = [];
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: undefined,
+    });
+    stubAttentionNeeded(false, true);
+  });
+
+  it("reports unsupported when Notification is unavailable", async () => {
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: undefined,
+    });
+
+    expect(getBrowserNotificationPermission()).toBe("unsupported");
+    await expect(requestBrowserNotificationPermission()).resolves.toBe(
+      "unsupported",
+    );
+  });
+
+  it("creates a notification when permission is granted and the page needs attention", () => {
+    vi.useFakeTimers();
+    stubNotification("granted");
+    stubAttentionNeeded(true, false);
+
+    expect(
+      showBrowserNotification({
+        title: "Porta job finished",
+        body: "Done",
+        tag: "porta:test",
+      }),
+    ).toBe(true);
+
+    expect(MockNotification.created).toHaveLength(1);
+    expect(MockNotification.created[0].title).toBe("Porta job finished");
+    expect(MockNotification.created[0].options).toMatchObject({
+      body: "Done",
+      tag: "porta:test",
+      icon: "/icons/icon-192.png",
+    });
+
+    vi.advanceTimersByTime(10_000);
+    expect(MockNotification.created[0].close).toHaveBeenCalled();
+  });
+
+  it("does not notify while the page is visible and focused", () => {
+    stubNotification("granted");
+    stubAttentionNeeded(false, true);
+
+    expect(showBrowserNotification({ title: "Noop" })).toBe(false);
+    expect(MockNotification.created).toHaveLength(0);
+  });
+
+  it("does not notify without granted permission", () => {
+    stubNotification("default");
+    stubAttentionNeeded(true, false);
+
+    expect(showBrowserNotification({ title: "Noop" })).toBe(false);
+    expect(MockNotification.created).toHaveLength(0);
+  });
+});

--- a/packages/web/src/__tests__/useChatNotifications.test.tsx
+++ b/packages/web/src/__tests__/useChatNotifications.test.tsx
@@ -1,0 +1,185 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useChatNotifications } from "../hooks/useChatNotifications";
+import { showBrowserNotification } from "../utils/browserNotifications";
+import type { TrajectoryStep } from "../types";
+
+vi.mock("../utils/browserNotifications", () => ({
+  showBrowserNotification: vi.fn(),
+}));
+
+const showBrowserNotificationMock = vi.mocked(showBrowserNotification);
+
+function waitingCommandStep(command = "npm install"): TrajectoryStep {
+  return {
+    type: "CORTEX_STEP_TYPE_RUN_COMMAND",
+    status: "CORTEX_STEP_STATUS_WAITING",
+    metadata: {
+      sourceTrajectoryStepInfo: {
+        trajectoryId: "traj-1",
+        stepIndex: 7,
+      },
+    },
+    runCommand: {
+      proposedCommandLine: command,
+    },
+  };
+}
+
+function waitingFilePermissionStep(path = "file:///app/src/App.tsx"): TrajectoryStep {
+  return {
+    type: "CORTEX_STEP_TYPE_VIEW_FILE",
+    status: "CORTEX_STEP_STATUS_WAITING",
+    metadata: {
+      sourceTrajectoryStepInfo: {
+        trajectoryId: "traj-1",
+        stepIndex: 8,
+      },
+    },
+    viewFile: {
+      absolutePathUri: path,
+      filePermissionRequest: {
+        absolutePathUri: path,
+      },
+    },
+  };
+}
+
+function assistantResponseStep(text: string): TrajectoryStep {
+  return {
+    type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+    plannerResponse: {
+      modifiedResponse: text,
+    },
+  };
+}
+
+describe("useChatNotifications", () => {
+  beforeEach(() => {
+    showBrowserNotificationMock.mockClear();
+  });
+
+  it("does not notify for approval requests present on initial load", () => {
+    renderHook(() =>
+      useChatNotifications({
+        cascadeId: "cascade-1",
+        steps: [waitingCommandStep()],
+        loading: false,
+        wsRunning: false,
+        isConversationRunning: false,
+        enabled: true,
+        conversationTitle: "Session",
+      }),
+    );
+
+    expect(showBrowserNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("notifies once for new command approval requests", () => {
+    const { rerender } = renderHook(
+      ({ steps }) =>
+        useChatNotifications({
+          cascadeId: "cascade-1",
+          steps,
+          loading: false,
+          wsRunning: false,
+          isConversationRunning: false,
+          enabled: true,
+          conversationTitle: "Session",
+        }),
+      { initialProps: { steps: [] as TrajectoryStep[] } },
+    );
+
+    rerender({ steps: [waitingCommandStep("pnpm test")] });
+    rerender({ steps: [waitingCommandStep("pnpm test")] });
+
+    expect(showBrowserNotificationMock).toHaveBeenCalledTimes(1);
+    expect(showBrowserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Porta needs approval",
+        body: "pnpm test",
+        tag: expect.stringContaining("command:traj-1:7:pnpm test"),
+      }),
+    );
+  });
+
+  it("notifies for new file permission requests", () => {
+    const { rerender } = renderHook(
+      ({ steps }) =>
+        useChatNotifications({
+          cascadeId: "cascade-1",
+          steps,
+          loading: false,
+          wsRunning: false,
+          isConversationRunning: false,
+          enabled: true,
+        }),
+      { initialProps: { steps: [] as TrajectoryStep[] } },
+    );
+
+    rerender({ steps: [waitingFilePermissionStep()] });
+
+    expect(showBrowserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Porta needs file access",
+        body: "/app/src/App.tsx",
+      }),
+    );
+  });
+
+  it("notifies once when websocket running transitions to idle", () => {
+    const { rerender } = renderHook(
+      ({ wsRunning }) =>
+        useChatNotifications({
+          cascadeId: "cascade-1",
+          steps: [
+            assistantResponseStep(
+              "Build completed successfully. I updated the notification tests.",
+            ),
+          ],
+          loading: false,
+          wsRunning,
+          isConversationRunning: false,
+          enabled: true,
+          conversationTitle: "Build",
+        }),
+      { initialProps: { wsRunning: true } },
+    );
+
+    rerender({ wsRunning: false });
+    rerender({ wsRunning: false });
+
+    expect(showBrowserNotificationMock).toHaveBeenCalledTimes(1);
+    expect(showBrowserNotificationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Porta job finished",
+        body: "Build completed successfully. I updated the notification tests.",
+      }),
+    );
+  });
+
+  it("tracks events while disabled without replaying them after enabling", () => {
+    const { rerender } = renderHook(
+      ({ enabled, steps }) =>
+        useChatNotifications({
+          cascadeId: "cascade-1",
+          steps,
+          loading: false,
+          wsRunning: false,
+          isConversationRunning: false,
+          enabled,
+        }),
+      {
+        initialProps: {
+          enabled: false,
+          steps: [] as TrajectoryStep[],
+        },
+      },
+    );
+
+    rerender({ enabled: false, steps: [waitingCommandStep()] });
+    rerender({ enabled: true, steps: [waitingCommandStep()] });
+
+    expect(showBrowserNotificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
+import { useChatNotifications } from "../hooks/useChatNotifications";
 import { useStepsStream } from "../hooks/useStepsStream";
 import { stepsToMessages } from "../transforms/stepsToMessages";
 import {
@@ -59,6 +60,8 @@ interface Props {
   hardRefreshKey?: number;
   totalStepCount?: number;
   isConversationRunning?: boolean;
+  browserNotificationsEnabled?: boolean;
+  conversationTitle?: string;
   /** Called when the WS reports the agent went idle — triggers sidebar refresh. */
   onSidebarRefresh?: () => void;
 }
@@ -387,6 +390,8 @@ export function ChatPanel({
   hardRefreshKey = 0,
   totalStepCount,
   isConversationRunning = false,
+  browserNotificationsEnabled = false,
+  conversationTitle,
   onSidebarRefresh,
 }: Props) {
   const {
@@ -403,7 +408,18 @@ export function ChatPanel({
     totalStepCount,
     onSidebarRefresh,
     isConversationRunning,
+    browserNotificationsEnabled,
   );
+
+  useChatNotifications({
+    cascadeId,
+    steps: rawSteps,
+    loading,
+    wsRunning,
+    isConversationRunning,
+    enabled: browserNotificationsEnabled,
+    conversationTitle,
+  });
 
   // Soft re-fetch when refreshKey changes (e.g. after send)
   const prevKeyRef = useRef(refreshKey);

--- a/packages/web/src/components/SettingsPanel.tsx
+++ b/packages/web/src/components/SettingsPanel.tsx
@@ -11,6 +11,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { IconChevronLeft, IconCheck } from "./Icons";
 import { api } from "../api/client";
+import {
+  getBrowserNotificationPermission,
+  requestBrowserNotificationPermission,
+  type BrowserNotificationPermission,
+} from "../utils/browserNotifications";
 import type { ClientSettings } from "../types";
 import type { PlannerType } from "./ChatInput";
 
@@ -32,6 +37,10 @@ export function SettingsPanel({ settings, onUpdate, onBack }: Props) {
   const [models, setModels] = useState<ModelConfig[]>([]);
   const [fetchError, setFetchError] = useState(false);
   const [savedFlash, setSavedFlash] = useState(false);
+  const [notificationPermission, setNotificationPermission] =
+    useState<BrowserNotificationPermission>(
+      getBrowserNotificationPermission,
+    );
 
   const fetchModels = useCallback(async (retries = 3) => {
     for (let i = 0; i < retries; i++) {
@@ -52,6 +61,24 @@ export function SettingsPanel({ settings, onUpdate, onBack }: Props) {
   useEffect(() => {
     fetchModels();
   }, [fetchModels]);
+
+  useEffect(() => {
+    const syncPermission = () => {
+      setNotificationPermission(getBrowserNotificationPermission());
+    };
+
+    window.addEventListener("focus", syncPermission);
+    return () => window.removeEventListener("focus", syncPermission);
+  }, []);
+
+  useEffect(() => {
+    if (
+      settings.browserNotificationsEnabled &&
+      notificationPermission !== "granted"
+    ) {
+      onUpdate({ browserNotificationsEnabled: false });
+    }
+  }, [notificationPermission, onUpdate, settings.browserNotificationsEnabled]);
 
   const flashSaved = useCallback(() => {
     setSavedFlash(true);
@@ -76,10 +103,43 @@ export function SettingsPanel({ settings, onUpdate, onBack }: Props) {
     [onUpdate, flashSaved],
   );
 
+  const handleNotificationsChange = useCallback(
+    async (checked: boolean) => {
+      if (!checked) {
+        onUpdate({ browserNotificationsEnabled: false });
+        flashSaved();
+        return;
+      }
+
+      const permission = await requestBrowserNotificationPermission();
+      setNotificationPermission(permission);
+      onUpdate({ browserNotificationsEnabled: permission === "granted" });
+      flashSaved();
+    },
+    [onUpdate, flashSaved],
+  );
+
   const handleReset = useCallback(() => {
-    onUpdate({ defaultModel: null, defaultPlannerType: "conversational" });
+    onUpdate({
+      defaultModel: null,
+      defaultPlannerType: "conversational",
+      browserNotificationsEnabled: false,
+    });
     flashSaved();
   }, [onUpdate, flashSaved]);
+
+  const notificationsChecked =
+    settings.browserNotificationsEnabled &&
+    notificationPermission === "granted";
+  const notificationsDisabled = notificationPermission === "unsupported";
+  const notificationStatus =
+    notificationPermission === "unsupported"
+      ? "Unsupported"
+      : notificationPermission === "denied"
+        ? "Blocked"
+        : notificationsChecked
+          ? "On"
+          : "Off";
 
   return (
     <div className="settings-panel">
@@ -148,6 +208,36 @@ export function SettingsPanel({ settings, onUpdate, onBack }: Props) {
               <option value="conversational">Fast</option>
               <option value="planning">Plan</option>
             </select>
+          </div>
+        </div>
+
+        {/* Notifications */}
+        <div className="settings-section">
+          <h2 className="settings-section-title">Notifications</h2>
+          <div className="settings-row">
+            <div className="settings-row-info">
+              <span className="settings-row-label">Browser Notifications</span>
+              <span className="settings-row-desc">
+                Run completion and approval requests.
+              </span>
+            </div>
+            <div className="settings-notification-control">
+              <span className="settings-permission-status">
+                {notificationStatus}
+              </span>
+              <label className="settings-switch">
+                <input
+                  type="checkbox"
+                  checked={notificationsChecked}
+                  disabled={notificationsDisabled}
+                  onChange={(e) => {
+                    void handleNotificationsChange(e.target.checked);
+                  }}
+                  aria-label="Browser Notifications"
+                />
+                <span className="settings-switch-track" />
+              </label>
+            </div>
           </div>
         </div>
 

--- a/packages/web/src/hooks/useChatNotifications.ts
+++ b/packages/web/src/hooks/useChatNotifications.ts
@@ -1,0 +1,197 @@
+import { useEffect, useRef } from "react";
+import { getFilePermissionRequest } from "../components/StepCards";
+import { showBrowserNotification } from "../utils/browserNotifications";
+import type { TrajectoryStep } from "../types";
+
+const WAITING_STATUS = "CORTEX_STEP_STATUS_WAITING";
+
+interface UseChatNotificationsOptions {
+  cascadeId: string;
+  steps: TrajectoryStep[];
+  loading: boolean;
+  wsRunning: boolean;
+  isConversationRunning: boolean;
+  enabled: boolean;
+  conversationTitle?: string;
+}
+
+interface PendingApprovalNotification {
+  key: string;
+  title: string;
+  body: string;
+}
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}...`;
+}
+
+function cleanNotificationText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function latestAssistantReplyPreview(steps: TrajectoryStep[]): string | null {
+  for (let index = steps.length - 1; index >= 0; index--) {
+    const step = steps[index];
+    if (step.type !== "CORTEX_STEP_TYPE_PLANNER_RESPONSE") continue;
+
+    const response =
+      step.plannerResponse?.modifiedResponse ??
+      step.plannerResponse?.items
+        ?.map((item) => item.text)
+        .filter((text): text is string => Boolean(text?.trim()))
+        .join("\n\n") ??
+      "";
+    const cleaned = cleanNotificationText(response);
+    if (cleaned) return truncate(cleaned, 180);
+  }
+
+  return null;
+}
+
+function stepIdentity(step: TrajectoryStep, index: number): string {
+  const info = step.metadata?.sourceTrajectoryStepInfo;
+  const trajectoryId =
+    info?.trajectoryId ?? step.metadata?.toolCall?.id ?? "local";
+  const stepIndex = info?.stepIndex ?? index;
+  return `${trajectoryId}:${stepIndex}`;
+}
+
+function pendingApprovalNotifications(
+  steps: TrajectoryStep[],
+): PendingApprovalNotification[] {
+  const notifications: PendingApprovalNotification[] = [];
+
+  steps.forEach((step, index) => {
+    if (step.status !== WAITING_STATUS) return;
+
+    const identity = stepIdentity(step, index);
+    const filePermissionRequest = getFilePermissionRequest(step);
+    if (filePermissionRequest) {
+      const path = filePermissionRequest.absolutePathUri.replace(
+        /^file:\/\//,
+        "",
+      );
+      notifications.push({
+        key: `file:${identity}:${filePermissionRequest.absolutePathUri}`,
+        title: "Porta needs file access",
+        body: truncate(path, 120),
+      });
+      return;
+    }
+
+    if (step.type !== "CORTEX_STEP_TYPE_RUN_COMMAND" || !step.runCommand) {
+      return;
+    }
+
+    const command =
+      step.runCommand.proposedCommandLine ??
+      step.runCommand.commandLine ??
+      step.runCommand.command ??
+      "";
+
+    notifications.push({
+      key: `command:${identity}:${command}`,
+      title: "Porta needs approval",
+      body: command ? truncate(command, 120) : "Approve or reject a command.",
+    });
+  });
+
+  return notifications;
+}
+
+export function useChatNotifications({
+  cascadeId,
+  steps,
+  loading,
+  wsRunning,
+  isConversationRunning,
+  enabled,
+  conversationTitle,
+}: UseChatNotificationsOptions): void {
+  const initializedRef = useRef(false);
+  const seenApprovalKeysRef = useRef<Set<string>>(new Set());
+  const prevWsRunningRef = useRef(wsRunning);
+  const prevOverallRunningRef = useRef(wsRunning || isConversationRunning);
+  const runFinishedNotifiedRef = useRef(false);
+  const cascadeRef = useRef(cascadeId);
+
+  useEffect(() => {
+    if (cascadeRef.current === cascadeId) return;
+
+    cascadeRef.current = cascadeId;
+    initializedRef.current = false;
+    seenApprovalKeysRef.current = new Set();
+    prevWsRunningRef.current = wsRunning;
+    prevOverallRunningRef.current = wsRunning || isConversationRunning;
+    runFinishedNotifiedRef.current = false;
+  }, [cascadeId, isConversationRunning, wsRunning]);
+
+  useEffect(() => {
+    if (loading) return;
+
+    const pendingApprovals = pendingApprovalNotifications(steps);
+    const currentPendingKeys = pendingApprovals.map(({ key }) => key);
+
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      seenApprovalKeysRef.current = new Set(currentPendingKeys);
+      prevWsRunningRef.current = wsRunning;
+      prevOverallRunningRef.current = wsRunning || isConversationRunning;
+      return;
+    }
+
+    const overallRunning = wsRunning || isConversationRunning;
+    const startedRunning =
+      (!prevWsRunningRef.current && wsRunning) ||
+      (!prevOverallRunningRef.current && overallRunning);
+
+    if (startedRunning) {
+      runFinishedNotifiedRef.current = false;
+    }
+
+    const finishedRunning =
+      (prevWsRunningRef.current && !wsRunning) ||
+      (prevOverallRunningRef.current && !overallRunning);
+
+    if (finishedRunning && !runFinishedNotifiedRef.current) {
+      if (enabled) {
+        const latestReply = latestAssistantReplyPreview(steps);
+        showBrowserNotification({
+          title: "Porta job finished",
+          body:
+            latestReply ??
+            (conversationTitle
+              ? `${conversationTitle} is now idle.`
+              : "The current session is now idle."),
+          tag: `porta:${cascadeId}:run-finished`,
+        });
+      }
+      runFinishedNotifiedRef.current = true;
+    }
+
+    for (const notification of pendingApprovals) {
+      if (seenApprovalKeysRef.current.has(notification.key)) continue;
+
+      if (enabled) {
+        showBrowserNotification({
+          title: notification.title,
+          body: notification.body,
+          tag: `porta:${cascadeId}:${notification.key}`,
+        });
+      }
+      seenApprovalKeysRef.current.add(notification.key);
+    }
+
+    prevWsRunningRef.current = wsRunning;
+    prevOverallRunningRef.current = overallRunning;
+  }, [
+    cascadeId,
+    conversationTitle,
+    enabled,
+    isConversationRunning,
+    loading,
+    steps,
+    wsRunning,
+  ]);
+}

--- a/packages/web/src/hooks/useClientSettings.ts
+++ b/packages/web/src/hooks/useClientSettings.ts
@@ -14,6 +14,7 @@ const STORAGE_KEY = "porta:settings";
 const DEFAULT_SETTINGS: ClientSettings = {
   defaultModel: DEFAULT_MODEL,
   defaultPlannerType: "conversational",
+  browserNotificationsEnabled: false,
 };
 
 function readSettings(): ClientSettings {

--- a/packages/web/src/hooks/useStepsStream.ts
+++ b/packages/web/src/hooks/useStepsStream.ts
@@ -44,6 +44,7 @@ export function useStepsStream(
   totalStepCount?: number,
   onIdleTransition?: () => void,
   isConversationRunning = false,
+  keepAliveWhenHidden = false,
 ): UseStepsStreamResult {
   const [steps, setSteps] = useState<TrajectoryStep[]>([]);
   const [loading, setLoading] = useState(true);
@@ -225,7 +226,13 @@ export function useStepsStream(
             wsRef.current = null;
           }
 
-          if (typeof document !== "undefined" && document.hidden) return;
+          if (
+            typeof document !== "undefined" &&
+            document.hidden &&
+            !keepAliveWhenHidden
+          ) {
+            return;
+          }
 
           const current = wsRef.current;
           if (current && current.readyState < WebSocket.CLOSING) return;
@@ -235,7 +242,13 @@ export function useStepsStream(
             reconnectTimerRef.current = null;
 
             if (!mountedRef.current || gen !== genRef.current) return;
-            if (typeof document !== "undefined" && document.hidden) return;
+            if (
+              typeof document !== "undefined" &&
+              document.hidden &&
+              !keepAliveWhenHidden
+            ) {
+              return;
+            }
 
             const activeSocket = wsRef.current;
             if (activeSocket && activeSocket.readyState < WebSocket.CLOSING) {
@@ -253,7 +266,7 @@ export function useStepsStream(
         // WS not available — no real-time updates
       }
     },
-    [cascadeId, clearReconnectTimer],
+    [cascadeId, clearReconnectTimer, keepAliveWhenHidden],
   );
 
   // ── Lifecycle: fetch + connect ──
@@ -292,6 +305,7 @@ export function useStepsStream(
 
     const onVisibilityChange = () => {
       if (!document.hidden) return;
+      if (keepAliveWhenHidden) return;
 
       clearReconnectTimer();
       setWsRunning(false);
@@ -307,7 +321,7 @@ export function useStepsStream(
     return () => {
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [clearReconnectTimer]);
+  }, [clearReconnectTimer, keepAliveWhenHidden]);
 
   // ── Lazy load older steps ──
   const loadOlder = useCallback(async (): Promise<number> => {

--- a/packages/web/src/styles/settings.css
+++ b/packages/web/src/styles/settings.css
@@ -140,6 +140,78 @@
   color: var(--text-primary);
 }
 
+/* Notification toggle */
+
+.settings-notification-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.settings-permission-status {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+.settings-switch {
+  position: relative;
+  display: inline-flex;
+  width: 42px;
+  height: 24px;
+}
+
+.settings-switch input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.settings-switch input:disabled {
+  cursor: not-allowed;
+}
+
+.settings-switch-track {
+  width: 100%;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  transition: all var(--transition-fast);
+}
+
+.settings-switch-track::after {
+  content: "";
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  transition: transform var(--transition-fast), background var(--transition-fast);
+}
+
+.settings-switch input:checked + .settings-switch-track {
+  background: rgb(var(--c-accent) / 0.25);
+  border-color: rgb(var(--c-accent) / 0.5);
+}
+
+.settings-switch input:checked + .settings-switch-track::after {
+  transform: translateX(18px);
+  background: rgb(var(--c-accent));
+}
+
+.settings-switch input:focus-visible + .settings-switch-track {
+  outline: 2px solid rgb(var(--c-accent) / 0.35);
+  outline-offset: 2px;
+}
+
+.settings-switch input:disabled + .settings-switch-track {
+  opacity: 0.5;
+}
+
 /* ── Feedback ── */
 
 .settings-saved-badge {

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -237,4 +237,6 @@ export interface ClientSettings {
   defaultModel: string | null;
   /** Planner type used when the user hasn't explicitly picked one per-message. */
   defaultPlannerType: "conversational" | "planning";
+  /** Enables browser notifications for run completion and approval requests. */
+  browserNotificationsEnabled: boolean;
 }

--- a/packages/web/src/utils/browserNotifications.ts
+++ b/packages/web/src/utils/browserNotifications.ts
@@ -1,0 +1,71 @@
+export type BrowserNotificationPermission =
+  | NotificationPermission
+  | "unsupported";
+
+interface ShowBrowserNotificationOptions {
+  title: string;
+  body?: string;
+  tag?: string;
+}
+
+export function getBrowserNotificationPermission(): BrowserNotificationPermission {
+  if (
+    typeof window === "undefined" ||
+    !("Notification" in window) ||
+    typeof window.Notification === "undefined"
+  ) {
+    return "unsupported";
+  }
+
+  return window.Notification.permission;
+}
+
+export async function requestBrowserNotificationPermission(): Promise<BrowserNotificationPermission> {
+  if (
+    typeof window === "undefined" ||
+    !("Notification" in window) ||
+    typeof window.Notification === "undefined"
+  ) {
+    return "unsupported";
+  }
+
+  return window.Notification.requestPermission();
+}
+
+export function shouldShowBrowserNotification(): boolean {
+  if (typeof document === "undefined") return true;
+
+  if (document.hidden) return true;
+  if (typeof document.hasFocus === "function") {
+    return !document.hasFocus();
+  }
+
+  return false;
+}
+
+export function showBrowserNotification({
+  title,
+  body,
+  tag,
+}: ShowBrowserNotificationOptions): boolean {
+  if (getBrowserNotificationPermission() !== "granted") return false;
+  if (!shouldShowBrowserNotification()) return false;
+
+  try {
+    const notification = new window.Notification(title, {
+      body,
+      tag,
+      icon: "/icons/icon-192.png",
+    });
+
+    notification.onclick = () => {
+      window.focus();
+      notification.close();
+    };
+
+    window.setTimeout(() => notification.close(), 10_000);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Add opt-in browser notifications in Settings
- Notify when the current run finishes, using the latest assistant reply excerpt when available
- Notify when command approval or file permission is needed
- Keep the step WebSocket alive while hidden only when browser notifications are enabled
- Add unit coverage and Chrome/CDP e2e coverage for notification permission and notification firing

Closes #66

Follow-up mobile/PWA Web Push support is tracked separately in #67.

## Verification

- pnpm --filter @porta/web test -- --run
- PORTA_E2E_CHROME_BIN="C:\Program Files\Google\Chrome\Application\chrome.exe" pnpm --filter @porta/web test:e2e
- pnpm --filter @porta/web build

## Notes

pnpm --filter @porta/web lint still fails on pre-existing unrelated lint issues in ChatInput.tsx, Sidebar.tsx, StepCards.tsx, useAppResume.ts, useDraftText.ts, and markdown.ts.
