### PR TITLE
feat(web): show implementation plan in chat

### DIFF
--- a/packages/web/e2e/app.e2e.test.ts
+++ b/packages/web/e2e/app.e2e.test.ts
@@ -66,8 +66,17 @@ describe("web e2e", () => {
     await page!.waitForPath("/porta/conv-1");
     await page!.waitForText(prompt);
     await page!.waitForText(`Mock response for: ${prompt}`);
+    await page!.waitForText("Implementation plan");
 
     expect(await page!.count(".message.user")).toBe(1);
     expect(await page!.count(".message.assistant")).toBe(1);
+    expect(await page!.count(".implementation-plan-block")).toBe(1);
+
+    await page!.click(".implementation-plan-header");
+    await page!.waitFor(
+      `Boolean(document.querySelector(".implementation-plan-block[open]"))`,
+      { timeoutMs: 5_000, description: "implementation plan to expand" },
+    );
+    expect(await page!.bodyText()).toContain("Inspecting mock conversation state.");
   });
 });

--- a/packages/web/src/__tests__/ChatPanel.test.tsx
+++ b/packages/web/src/__tests__/ChatPanel.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatPanel } from "../components/ChatPanel";
+import { useStepsStream } from "../hooks/useStepsStream";
+import type { TrajectoryStep } from "../types";
+
+vi.mock("../hooks/useStepsStream", () => ({
+  useStepsStream: vi.fn(),
+}));
+
+vi.mock("../hooks/useChatNotifications", () => ({
+  useChatNotifications: vi.fn(),
+}));
+
+const mockUseStepsStream = vi.mocked(useStepsStream);
+
+function mockSteps(steps: TrajectoryStep[], wsRunning = false) {
+  mockUseStepsStream.mockReturnValue({
+    steps,
+    loading: false,
+    error: null,
+    hasMore: false,
+    loadingOlder: false,
+    wsRunning,
+    loadOlder: vi.fn().mockResolvedValue(0),
+    refresh: vi.fn(),
+    hardRefresh: vi.fn(),
+  });
+}
+
+describe("ChatPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders planner thinking as an implementation plan panel", () => {
+    mockSteps([
+      {
+        type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+        plannerResponse: {
+          modifiedResponse: "I will make the change.",
+          thinking: "Inspect the current chat UI, then expose the plan.",
+          thinkingDuration: "3.4s",
+        },
+      },
+    ]);
+
+    render(
+      <ChatPanel
+        cascadeId="cascade-1"
+        onRevert={vi.fn()}
+        onFilePermission={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Implementation plan")).toBeInTheDocument();
+    expect(screen.getByText("View")).toBeInTheDocument();
+    expect(screen.getByText("3.4s")).toBeInTheDocument();
+    expect(
+      screen.getByText("Inspect the current chat UI, then expose the plan."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the latest plan as a live panel while the run is active", () => {
+    mockSteps(
+      [
+        {
+          type: "CORTEX_STEP_TYPE_USER_INPUT",
+          userInput: { items: [{ text: "Please implement this" }] },
+        },
+        {
+          type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+          plannerResponse: {
+            thinking: "Inspect first, then patch the UI.",
+            thinkingDuration: "1.2s",
+          },
+        },
+      ],
+      true,
+    );
+
+    render(
+      <ChatPanel
+        cascadeId="cascade-1"
+        onRevert={vi.fn()}
+        onFilePermission={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Live implementation plan")).toBeInTheDocument();
+    expect(screen.getByText("Live")).toBeInTheDocument();
+    expect(screen.getByText("Hide")).toBeInTheDocument();
+    expect(
+      document.querySelector(".pinned-implementation-plan-message"),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the live plan pinned above the answer after the run ends", () => {
+    const steps: TrajectoryStep[] = [
+      {
+        type: "CORTEX_STEP_TYPE_USER_INPUT",
+        userInput: { items: [{ text: "Please implement this" }] },
+      },
+      {
+        type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+        plannerResponse: {
+          thinking: "Inspect first, then patch the UI.",
+          thinkingDuration: "1.2s",
+        },
+      },
+    ];
+    const completedSteps: TrajectoryStep[] = [
+      ...steps,
+      {
+        type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+        plannerResponse: {
+          modifiedResponse: "Final answer.",
+        },
+      },
+    ];
+    const props = {
+      cascadeId: "cascade-1",
+      onRevert: vi.fn(),
+      onFilePermission: vi.fn(),
+    };
+
+    mockSteps(steps, true);
+    const { rerender } = render(<ChatPanel {...props} />);
+    expect(screen.getByText("Live implementation plan")).toBeInTheDocument();
+
+    mockSteps(completedSteps, false);
+    rerender(<ChatPanel {...props} />);
+
+    expect(
+      screen.queryByText("Live implementation plan"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Live")).not.toBeInTheDocument();
+    expect(screen.getByText("Implementation plan")).toBeInTheDocument();
+    const messageElements = Array.from(document.querySelectorAll(".message"));
+    const planElement = document.querySelector(
+      ".pinned-implementation-plan-message",
+    );
+    const answerElement = screen.getByText("Final answer.");
+    const planIndex = messageElements.indexOf(planElement as Element);
+    const answerIndex = messageElements.findIndex((element) =>
+      element.contains(answerElement),
+    );
+
+    expect(planElement).toBeInTheDocument();
+    expect(planIndex).toBeGreaterThanOrEqual(0);
+    expect(answerIndex).toBeGreaterThan(planIndex);
+  });
+});

--- a/packages/web/src/__tests__/stepsToMessages.test.ts
+++ b/packages/web/src/__tests__/stepsToMessages.test.ts
@@ -110,6 +110,22 @@ describe("stepsToMessages", () => {
     expect(msgs[0].thinkingDuration).toBe("2.5s");
   });
 
+  it("uses planner response items when modifiedResponse is empty", () => {
+    const step: TrajectoryStep = {
+      type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",
+      plannerResponse: {
+        modifiedResponse: "",
+        items: [{ text: "Inspect current UI" }, { text: "Add plan panel" }],
+      },
+    };
+
+    const msgs = stepsToMessages([step]);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].role).toBe("assistant");
+    expect(msgs[0].content).toBe("Inspect current UI\n\nAdd plan panel");
+  });
+
   it("skips planner response with empty text and no thinking", () => {
     const step: TrajectoryStep = {
       type: "CORTEX_STEP_TYPE_PLANNER_RESPONSE",

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  Fragment,
   memo,
   useCallback,
   useEffect,
@@ -36,6 +37,7 @@ import {
   IconEye,
   IconMessageCircle,
   IconAlertTriangle,
+  IconChevron,
 } from "./Icons";
 import type { ChatMessage } from "../types";
 
@@ -66,14 +68,19 @@ interface Props {
   onSidebarRefresh?: () => void;
 }
 
-/** Collapsible thinking/reasoning block */
-function ThinkingBlock({
-  thinking,
+/** Collapsible implementation plan block */
+function ImplementationPlanBlock({
+  plan,
   duration,
+  live = false,
 }: {
-  thinking: string;
+  plan: string;
   duration?: string;
+  live?: boolean;
 }) {
+  const [copied, setCopied] = useState(false);
+  const [open, setOpen] = useState(live);
+  const renderedPlan = useMemo(() => renderMarkdown(plan), [plan]);
   let durationLabel = "";
   if (duration) {
     const match = duration.match(/([\d.]+)s/);
@@ -83,16 +90,95 @@ function ThinkingBlock({
   }
 
   return (
-    <details className="thinking-block">
-      <summary className="thinking-header">
-        <span className="thinking-chevron">›</span>
-        <span className="thinking-label">
-          Thinking{durationLabel ? ` for ${durationLabel}` : ""}
+    <details
+      className={`implementation-plan-block${live ? " live" : ""}`}
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className="implementation-plan-header">
+        <span className="implementation-plan-icon">
+          <IconList size={13} />
+        </span>
+        <span className="implementation-plan-label">
+          {live ? "Live implementation plan" : "Implementation plan"}
+        </span>
+        {live && (
+          <span className="implementation-plan-live-badge">Live</span>
+        )}
+        {durationLabel && (
+          <span className="implementation-plan-meta">{durationLabel}</span>
+        )}
+        <span className="implementation-plan-action">
+          {open ? "Hide" : "View"}
+        </span>
+        <span className="implementation-plan-chevron">
+          <IconChevron size={13} />
         </span>
       </summary>
-      <div className="thinking-content">{thinking}</div>
+      <div className="implementation-plan-content">
+        <MarkdownContent html={renderedPlan} />
+        <div className="implementation-plan-actions">
+          <button
+            className="msg-action-btn implementation-plan-copy"
+            title="Copy implementation plan"
+            onClick={() => {
+              navigator.clipboard.writeText(plan).then(() => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              });
+            }}
+          >
+            {copied ? <IconCheck size={13} /> : <IconCopy size={13} />}
+          </button>
+        </div>
+      </div>
     </details>
   );
+}
+
+function textFromStepItems(items?: { text?: string }[]): string {
+  if (!items) return "";
+  return items
+    .filter((item) => item.text?.trim())
+    .map((item) => item.text!.trim())
+    .join("\n\n");
+}
+
+function implementationPlanFromStep(step: ChatMessage["step"]): string {
+  const plannerResponse = step?.plannerResponse;
+  if (!plannerResponse) return "";
+
+  const thinking = plannerResponse.thinking?.trim();
+  if (thinking) return plannerResponse.thinking ?? "";
+
+  const itemText = textFromStepItems(plannerResponse.items);
+  if (!plannerResponse.modifiedResponse?.trim() && itemText) return itemText;
+
+  return "";
+}
+
+interface LiveImplementationPlan {
+  plan: string;
+  duration?: string;
+  stepIndex: number;
+}
+
+function latestImplementationPlan(
+  steps: ChatMessage["step"][],
+): LiveImplementationPlan | null {
+  for (let index = steps.length - 1; index >= 0; index--) {
+    const step = steps[index];
+    const plan = implementationPlanFromStep(step);
+    if (plan.trim()) {
+      return {
+        plan,
+        duration: step?.plannerResponse?.thinkingDuration,
+        stepIndex: index,
+      };
+    }
+  }
+
+  return null;
 }
 
 /** Map icon key → Lucide component */
@@ -117,6 +203,30 @@ function MsgIcon({ name }: { name?: string }) {
     default:
       return null;
   }
+}
+
+function PinnedImplementationPlanMessage({
+  implementationPlan,
+  live,
+}: {
+  implementationPlan: LiveImplementationPlan;
+  live: boolean;
+}) {
+  return (
+    <div className="message assistant pinned-implementation-plan-message">
+      <div
+        className={`chat-block message-body pinned-implementation-plan-body${
+          live ? " live" : ""
+        }`}
+      >
+        <ImplementationPlanBlock
+          plan={implementationPlan.plan}
+          duration={implementationPlan.duration}
+          live={live}
+        />
+      </div>
+    </div>
+  );
 }
 
 function SystemMessage({
@@ -258,6 +368,7 @@ interface MessageBubbleProps {
   msg: ChatMessage;
   isLocked: boolean;
   isUnconfirmed: boolean;
+  suppressImplementationPlan?: boolean;
   onRevert: (stepIndex: number, editText?: string) => void;
   onImageClick: (src: string) => void;
 }
@@ -267,6 +378,7 @@ const MessageBubble = memo(
     msg,
     isLocked,
     isUnconfirmed,
+    suppressImplementationPlan = false,
     onRevert,
     onImageClick,
   }: MessageBubbleProps) {
@@ -274,15 +386,25 @@ const MessageBubble = memo(
       () => (msg.content ? renderMarkdown(msg.content) : ""),
       [msg.content],
     );
+    const showImplementationPlan =
+      Boolean(msg.thinking) && !suppressImplementationPlan;
+
+    if (
+      !showImplementationPlan &&
+      !msg.content &&
+      (!msg.media || msg.media.length === 0)
+    ) {
+      return null;
+    }
 
     return (
       <div
         className={`message ${msg.role}${isUnconfirmed ? " unconfirmed" : ""}`}
       >
         <div className="chat-block message-body">
-          {msg.thinking && (
-            <ThinkingBlock
-              thinking={msg.thinking}
+          {showImplementationPlan && msg.thinking && (
+            <ImplementationPlanBlock
+              plan={msg.thinking}
               duration={msg.thinkingDuration}
             />
           )}
@@ -319,11 +441,13 @@ const MessageBubble = memo(
   (prev, next) =>
     prev.msg.content === next.msg.content &&
     prev.msg.thinking === next.msg.thinking &&
+    prev.msg.thinkingDuration === next.msg.thinkingDuration &&
     prev.msg.stepIndex === next.msg.stepIndex &&
     prev.msg.role === next.msg.role &&
     prev.msg.media === next.msg.media &&
     prev.isLocked === next.isLocked &&
-    prev.isUnconfirmed === next.isUnconfirmed,
+    prev.isUnconfirmed === next.isUnconfirmed &&
+    prev.suppressImplementationPlan === next.suppressImplementationPlan,
 );
 
 /** Fullscreen image lightbox with swipe-down-to-dismiss */
@@ -421,6 +545,11 @@ export function ChatPanel({
     conversationTitle,
   });
 
+  const [
+    pinnedImplementationPlanStepIndex,
+    setPinnedImplementationPlanStepIndex,
+  ] = useState<number | null>(null);
+
   // Soft re-fetch when refreshKey changes (e.g. after send)
   const prevKeyRef = useRef(refreshKey);
   useEffect(() => {
@@ -445,10 +574,15 @@ export function ChatPanel({
     if (cascadeId !== prevCascadeRef.current) {
       prevCascadeRef.current = cascadeId;
       didInitialScroll.current = false;
+      setPinnedImplementationPlanStepIndex(null);
     }
   }, [cascadeId]);
 
   const serverMessages = useMemo(() => stepsToMessages(rawSteps), [rawSteps]);
+  const liveImplementationPlan = useMemo(
+    () => latestImplementationPlan(rawSteps),
+    [rawSteps],
+  );
   const {
     messages,
     confirmedOptimisticIds,
@@ -465,6 +599,29 @@ export function ChatPanel({
 
   const isLocked = wsRunning || hasUnconfirmedOptimistic;
   const showTyping = wsRunning || hasUnconfirmedOptimistic;
+  const liveImplementationPlanActive =
+    showTyping && liveImplementationPlan !== null;
+  const pinnedImplementationPlan =
+    liveImplementationPlan &&
+    (liveImplementationPlanActive ||
+      pinnedImplementationPlanStepIndex === liveImplementationPlan.stepIndex)
+      ? liveImplementationPlan
+      : null;
+  const pinnedPlanInsertBeforeMessageIndex = useMemo(() => {
+    if (!pinnedImplementationPlan) return -1;
+    return messages.findIndex(
+      (msg) =>
+        msg.role === "assistant" &&
+        msg.stepIndex >= pinnedImplementationPlan.stepIndex &&
+        Boolean(msg.content.trim()),
+    );
+  }, [messages, pinnedImplementationPlan]);
+
+  useEffect(() => {
+    if (liveImplementationPlanActive && liveImplementationPlan) {
+      setPinnedImplementationPlanStepIndex(liveImplementationPlan.stepIndex);
+    }
+  }, [liveImplementationPlanActive, liveImplementationPlan]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const didInitialScroll = useRef(false);
@@ -642,28 +799,51 @@ export function ChatPanel({
         )}
 
         {messages.map((msg, i) => {
+          const messageKey = msg.optimisticId ?? `${msg.stepIndex}-${i}`;
+          const pinnedPlanNode =
+            pinnedImplementationPlan &&
+            i === pinnedPlanInsertBeforeMessageIndex ? (
+              <PinnedImplementationPlanMessage
+                implementationPlan={pinnedImplementationPlan}
+                live={liveImplementationPlanActive}
+              />
+            ) : null;
+
           if (msg.role === "system") {
             return (
-              <SystemMessage
-                key={`${msg.stepIndex}-${i}`}
-                msg={msg}
-                onFilePermission={onFilePermission}
-                onCommandAction={onCommandAction}
-              />
+              <Fragment key={messageKey}>
+                {pinnedPlanNode}
+                <SystemMessage
+                  msg={msg}
+                  onFilePermission={onFilePermission}
+                  onCommandAction={onCommandAction}
+                />
+              </Fragment>
             );
           }
 
           return (
-            <MessageBubble
-              key={msg.optimisticId ?? `${msg.stepIndex}-${i}`}
-              msg={msg}
-              isLocked={isLocked}
-              isUnconfirmed={isUnconfirmedOptimisticMessage(msg)}
-              onRevert={onRevert}
-              onImageClick={setLightboxSrc}
-            />
+            <Fragment key={messageKey}>
+              {pinnedPlanNode}
+              <MessageBubble
+                msg={msg}
+                isLocked={isLocked}
+                isUnconfirmed={isUnconfirmedOptimisticMessage(msg)}
+                suppressImplementationPlan={
+                  pinnedImplementationPlan?.stepIndex === msg.stepIndex
+                }
+                onRevert={onRevert}
+                onImageClick={setLightboxSrc}
+              />
+            </Fragment>
           );
         })}
+        {pinnedImplementationPlan && pinnedPlanInsertBeforeMessageIndex < 0 && (
+          <PinnedImplementationPlanMessage
+            implementationPlan={pinnedImplementationPlan}
+            live={liveImplementationPlanActive}
+          />
+        )}
         {showTyping && (
           <div className="message assistant">
             <div className="message-body">

--- a/packages/web/src/styles/chat-states.css
+++ b/packages/web/src/styles/chat-states.css
@@ -120,7 +120,141 @@ details[open] .thinking-chevron {
   overflow-y: auto;
 }
 
-/* ── Message action buttons (copy, revert) ── */
+/* Implementation plan panel */
+
+.implementation-plan-block {
+  margin-bottom: 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: rgb(var(--c-lift) / 0.03);
+  overflow: hidden;
+}
+
+.implementation-plan-block.live {
+  border-color: rgb(var(--c-accent) / 0.45);
+  background: rgb(var(--c-accent) / 0.07);
+  box-shadow: 0 0 0 1px rgb(var(--c-accent) / 0.12) inset;
+}
+
+.implementation-plan-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 8px 10px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  font-size: 12px;
+  user-select: none;
+  list-style: none;
+}
+
+.implementation-plan-header:hover {
+  background: rgb(var(--c-lift) / 0.04);
+  color: var(--text-primary);
+}
+
+.implementation-plan-header::-webkit-details-marker {
+  display: none;
+}
+
+.implementation-plan-icon,
+.implementation-plan-chevron {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--text-accent);
+}
+
+.implementation-plan-label {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.implementation-plan-meta {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.implementation-plan-live-badge {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgb(var(--c-accent) / 0.16);
+  color: var(--text-accent);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
+.implementation-plan-action {
+  flex-shrink: 0;
+  color: var(--text-accent);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.implementation-plan-chevron {
+  transition: transform var(--transition-fast);
+}
+
+.implementation-plan-block[open] .implementation-plan-chevron {
+  transform: rotate(180deg);
+}
+
+.implementation-plan-content {
+  max-height: 420px;
+  overflow-y: auto;
+  padding: 10px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.implementation-plan-content > :first-child {
+  margin-top: 0;
+}
+
+.implementation-plan-content > :last-child {
+  margin-bottom: 0;
+}
+
+.implementation-plan-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 4px;
+}
+
+.implementation-plan-copy {
+  width: 24px;
+  height: 24px;
+}
+
+.pinned-implementation-plan-message {
+  width: 100%;
+}
+
+.pinned-implementation-plan-body.live {
+  background: rgb(var(--c-accent) / 0.04);
+  border-color: rgb(var(--c-accent) / 0.22);
+}
+
+.pinned-implementation-plan-body .implementation-plan-block {
+  margin-bottom: 0;
+}
+
+/* Message action buttons (copy, revert) */
 
 .msg-actions {
   display: flex;

--- a/packages/web/src/styles/responsive.css
+++ b/packages/web/src/styles/responsive.css
@@ -245,9 +245,27 @@
     padding: 0 8px;
   }
 
-  /* ── Thinking block ── */
+  /* ── Implementation plan panel ── */
 
-  .thinking-content {
+  .implementation-plan-header {
+    min-height: 34px;
+    padding: 7px 8px;
+    gap: 6px;
+    font-size: 11px;
+  }
+
+  .implementation-plan-meta,
+  .implementation-plan-action {
+    font-size: 10px;
+  }
+
+  .implementation-plan-live-badge {
+    padding: 0 5px;
+    font-size: 9px;
+    line-height: 14px;
+  }
+
+  .implementation-plan-content {
     font-size: 11px;
     max-height: 250px;
     padding: 6px 8px;

--- a/packages/web/src/transforms/stepsToMessages.ts
+++ b/packages/web/src/transforms/stepsToMessages.ts
@@ -1,6 +1,14 @@
 import type { ChatMessage, TrajectoryStep } from "../types";
 import { getFilePermissionRequest } from "../components/StepCards";
 
+function textFromItems(items?: { text?: string }[]): string {
+  if (!items) return "";
+  return items
+    .filter((item) => item.text?.trim())
+    .map((item) => item.text!.trim())
+    .join("\n\n");
+}
+
 /** Extract displayable messages from raw trajectory steps */
 export function stepsToMessages(steps: TrajectoryStep[]): ChatMessage[] {
   const messages: ChatMessage[] = [];
@@ -23,14 +31,12 @@ export function stepsToMessages(steps: TrajectoryStep[]): ChatMessage[] {
     }
 
     if (type === "CORTEX_STEP_TYPE_USER_INPUT" && step.userInput?.items) {
-      const texts = step.userInput.items
-        .filter((item) => item.text?.trim())
-        .map((item) => item.text!.trim());
+      const text = textFromItems(step.userInput.items);
       const media = step.userInput.media;
-      if (texts.length > 0 || (media && media.length > 0)) {
+      if (text || (media && media.length > 0)) {
         messages.push({
           role: "user",
-          content: texts.join("\n\n"),
+          content: text,
           stepIndex: i,
           type,
           optimisticId: step.clientMessageId,
@@ -41,7 +47,8 @@ export function stepsToMessages(steps: TrajectoryStep[]): ChatMessage[] {
       const pr = step.plannerResponse;
       if (!pr) continue;
 
-      const text = pr.modifiedResponse ?? "";
+      const itemText = textFromItems(pr.items);
+      const text = pr.modifiedResponse?.trim() ? pr.modifiedResponse : itemText;
       const thinking = pr.thinking ?? "";
       const thinkingDuration = pr.thinkingDuration ?? "";
 


### PR DESCRIPTION
## Summary
- Display Antigravity planner output as an Implementation plan panel instead of generic thinking text
- Show the latest plan live while the run is active, then keep it pinned above the assistant answer after completion
- Add responsive styling and tests for planner item fallbacks, live/pinned plan behavior, and e2e expectations

Closes #65

## Test Plan
- pnpm --filter @porta/web test -- --run src/__tests__/ChatPanel.test.tsx
- pnpm --filter @porta/web test -- --run
- pnpm --filter @porta/web build
- git diff --check

## Notes
- pnpm --filter @porta/web test:e2e was not run locally because this environment has no Chrome/Chromium binary configured for PORTA_E2E_CHROME_BIN.