### PR TITLE
chore: sync v0.8.0 release metadata to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-09
+
+### Added
+
+- **Browser notifications can now alert users when an agent run completes or
+  approval is requested**, with a Settings toggle and permission handling for
+  supported browsers. (#66, #69)
+
+### Fixed
+
+- **Antigravity generated implementation plans are now visible in chat** as a
+  dedicated Implementation plan panel, including live display during active
+  runs and pinned placement above the assistant response after completion.
+  (#65, #71)
+
 ## [0.7.0] - 2026-06-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/L1M80/porta/actions/workflows/ci.yml/badge.svg)](https://github.com/L1M80/porta/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.7.0-green)
+![Version](https://img.shields.io/badge/version-0.8.0-green)
 
 Remote web interface for [Antigravity](https://antigravity.google/) Agent Manager.  
 Access your local Antigravity sessions from your phone, tablet, or any remote browser through a lightweight LSP bridge.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "porta",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev.mjs",


### PR DESCRIPTION
## Summary
- Sync v0.8.0 release metadata back to develop
- Update root version, README badge, and CHANGELOG

## Verification
- git diff --check