### PR TITLE
feat: search both antigravity and antigravity-ide daemon directories

### DIFF
--- a/packages/proxy/src/discovery.ts
+++ b/packages/proxy/src/discovery.ts
@@ -33,40 +33,45 @@ export interface LSInstance {
   source: "daemon" | "process";
 }
 
-const DAEMON_DIR = join(homedir(), ".gemini", "antigravity", "daemon");
+const DAEMON_DIRS = [
+  join(homedir(), ".gemini", "antigravity", "daemon"),
+  join(homedir(), ".gemini", "antigravity-ide", "daemon"),
+];
 const SERVICE_PREFIX = "exa.language_server_pb.LanguageServerService";
 
 async function discoverFromDaemon(): Promise<LSInstance[]> {
   const instances: LSInstance[] = [];
 
-  try {
-    const files = await readdir(DAEMON_DIR);
-    const lsFiles = files.filter(
-      (file) => file.startsWith("ls_") && file.endsWith(".json"),
-    );
+  for (const daemonDir of DAEMON_DIRS) {
+    try {
+      const files = await readdir(daemonDir);
+      const lsFiles = files.filter(
+        (file) => file.startsWith("ls_") && file.endsWith(".json"),
+      );
 
-    for (const file of lsFiles) {
-      try {
-        const raw = await readFile(join(DAEMON_DIR, file), "utf-8");
-        const data = JSON.parse(raw);
+      for (const file of lsFiles) {
+        try {
+          const raw = await readFile(join(daemonDir, file), "utf-8");
+          const data = JSON.parse(raw);
 
-        if (!data.pid || !data.httpsPort || !data.csrfToken) continue;
-        if (!(await platformAdapter.isPidAlive(data.pid))) continue;
+          if (!data.pid || !data.httpsPort || !data.csrfToken) continue;
+          if (!(await platformAdapter.isPidAlive(data.pid))) continue;
 
-        instances.push({
-          pid: data.pid,
-          httpsPort: data.httpsPort,
-          httpPort: data.httpPort ?? 0,
-          lspPort: data.lspPort ?? 0,
-          csrfToken: data.csrfToken,
-          source: "daemon",
-        });
-      } catch {
-        // Skip malformed files
+          instances.push({
+            pid: data.pid,
+            httpsPort: data.httpsPort,
+            httpPort: data.httpPort ?? 0,
+            lspPort: data.lspPort ?? 0,
+            csrfToken: data.csrfToken,
+            source: "daemon",
+          });
+        } catch {
+          // Skip malformed files
+        }
       }
+    } catch {
+      // Daemon dir missing or unreadable
     }
-  } catch {
-    // Daemon dir missing or unreadable
   }
 
   return instances;


### PR DESCRIPTION
This PR updates the local Language Server discovery to look inside both standard `antigravity` and `antigravity-ide` directories. This ensures that users running the IDE-based Language Server can have their active sessions successfully discovered by the Porta proxy out of the box.