### PR TITLE
fix: support Antigravity 2.x routing and workspace display

### DIFF
--- a/packages/proxy/src/__tests__/conversations-route.test.ts
+++ b/packages/proxy/src/__tests__/conversations-route.test.ts
@@ -132,6 +132,48 @@ describe("GET /api/conversations", () => {
       { workspaceFolderAbsoluteUri: "file:///home/user/project" },
     ]);
   });
+
+  it("learns affinity before filtering inactive scoped workspace summaries", async () => {
+    const scopedLS = makeInstance({
+      pid: 4,
+      workspaceId: "file_home_user_active",
+    });
+    mockGetInstances.mockResolvedValue([scopedLS]);
+    mockScanDiskConversations.mockResolvedValue([
+      { id: "c-inactive", mtime: "2026-06-01T00:00:00.000Z" },
+    ]);
+    mockRpcCall.mockImplementation(async (method) => {
+      if (method === "GetAllCascadeTrajectories") {
+        return {
+          trajectorySummaries: {
+            "c-inactive": {
+              summary: "Inactive workspace",
+              stepCount: 9,
+              lastModifiedTime: "2026-06-01T00:00:00.000Z",
+              workspaces: [
+                { workspaceFolderAbsoluteUri: "file:///home/user/inactive" },
+              ],
+            },
+          },
+        };
+      }
+      return { steps: [] };
+    });
+
+    const res = await app().request("/api/conversations");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(conversationAffinity.get("c-inactive")).toBe(
+      "file_home_user_inactive",
+    );
+    expect(body.trajectorySummaries["c-inactive"]).toMatchObject({
+      _diskOnly: true,
+      workspaces: [
+        { workspaceFolderAbsoluteUri: "file:///home/user/inactive" },
+      ],
+    });
+  });
 });
 
 describe("POST /api/conversations", () => {

--- a/packages/proxy/src/__tests__/discovery.test.ts
+++ b/packages/proxy/src/__tests__/discovery.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer, type Server } from "node:http";
 import type { LSInstance } from "../discovery.js";
-import { LSDiscovery } from "../discovery.js";
+import { LSDiscovery, probeConnectRpcPort } from "../discovery.js";
 
 function makeInstance(overrides: Partial<LSInstance> = {}): LSInstance {
   return {
@@ -35,6 +36,33 @@ function deferred<T>() {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+async function listenWithStatus(statusCode: number): Promise<{
+  server: Server;
+  port: number;
+}> {
+  const server = createServer((_req, res) => {
+    res.statusCode = statusCode;
+    res.end("{}");
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP server address");
+  }
+
+  return { server, port: address.port };
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
 }
 
 describe("LSDiscovery caching and lookup", () => {
@@ -207,5 +235,21 @@ describe("LSDiscovery caching and lookup", () => {
     await discovery.getInstance();
 
     expect(mockDiscover).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("probeConnectRpcPort", () => {
+  it("skips non-200 responses when discovering the RPC port", async () => {
+    const notRpc = await listenWithStatus(404);
+    const rpc = await listenWithStatus(200);
+
+    try {
+      await expect(
+        probeConnectRpcPort([notRpc.port, rpc.port], "test-token"),
+      ).resolves.toBe(rpc.port);
+    } finally {
+      await closeServer(notRpc.server);
+      await closeServer(rpc.server);
+    }
   });
 });

--- a/packages/proxy/src/__tests__/metadata.test.ts
+++ b/packages/proxy/src/__tests__/metadata.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from "vitest";
+import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   extractConversationWorkspaces,
   getMetadata,
   getPrimaryWorkspaceUri,
+  scanDiskConversations,
   withNormalizedConversationWorkspaces,
 } from "../metadata.js";
 
@@ -88,5 +92,51 @@ describe("conversation workspace metadata helpers", () => {
     expect(extractConversationWorkspaces(summary)).toEqual([
       { workspaceFolderAbsoluteUri: "file:///tmp/from-uri" },
     ]);
+  });
+});
+
+describe("scanDiskConversations", () => {
+  it("scans .pb and .db conversations while ignoring SQLite sidecar files", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "porta-conversations-"));
+    try {
+      await writeFile(join(dir, "legacy.pb"), "");
+      await writeFile(join(dir, "modern.db"), "");
+      await writeFile(join(dir, "modern.db-wal"), "");
+      await writeFile(join(dir, "modern.db-shm"), "");
+      await writeFile(join(dir, "notes.txt"), "");
+
+      const legacyTime = new Date("2026-06-01T00:00:00.000Z");
+      const modernTime = new Date("2026-06-02T00:00:00.000Z");
+      await utimes(join(dir, "legacy.pb"), legacyTime, legacyTime);
+      await utimes(join(dir, "modern.db"), modernTime, modernTime);
+
+      const results = await scanDiskConversations(dir);
+
+      expect(results.sort((a, b) => a.id.localeCompare(b.id))).toEqual([
+        { id: "legacy", mtime: legacyTime.toISOString() },
+        { id: "modern", mtime: modernTime.toISOString() },
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("deduplicates matching .pb and .db files by newest mtime", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "porta-conversations-"));
+    try {
+      await writeFile(join(dir, "same.pb"), "");
+      await writeFile(join(dir, "same.db"), "");
+
+      const oldTime = new Date("2026-06-01T00:00:00.000Z");
+      const newTime = new Date("2026-06-03T00:00:00.000Z");
+      await utimes(join(dir, "same.pb"), oldTime, oldTime);
+      await utimes(join(dir, "same.db"), newTime, newTime);
+
+      expect(await scanDiskConversations(dir)).toEqual([
+        { id: "same", mtime: newTime.toISOString() },
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/proxy/src/__tests__/origins.test.ts
+++ b/packages/proxy/src/__tests__/origins.test.ts
@@ -21,6 +21,33 @@ describe("origin policy", () => {
     );
   });
 
+  it("allows origins for PORTA_HOST on any port", () => {
+    const allowedOrigins = getAllowedOrigins({
+      PORTA_HOST: "172.20.1.2",
+    });
+
+    expect(isAllowedOrigin("http://172.20.1.2:5173", allowedOrigins)).toBe(
+      true,
+    );
+    expect(isAllowedOrigin("https://172.20.1.2", allowedOrigins)).toBe(true);
+    expect(isAllowedOrigin("http://172.20.1.3:5173", allowedOrigins)).toBe(
+      false,
+    );
+  });
+
+  it("allows bracketed IPv6 PORTA_HOST origins", () => {
+    const allowedOrigins = getAllowedOrigins({
+      PORTA_HOST: "fd7a:115c:a1e0::1",
+    });
+
+    expect(isAllowedOrigin("http://[fd7a:115c:a1e0::1]:5173", allowedOrigins)).toBe(
+      true,
+    );
+    expect(isAllowedOrigin("http://fd7a:115c:a1e0::1:5173", allowedOrigins)).toBe(
+      false,
+    );
+  });
+
   it("maps rejected origins to null for CORS middleware", () => {
     const allowedOrigins = getAllowedOrigins({});
 

--- a/packages/proxy/src/__tests__/routing.test.ts
+++ b/packages/proxy/src/__tests__/routing.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { uriToWorkspaceId, normalizeWorkspaceId } from "../routing.js";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  uriToWorkspaceId,
+  normalizeWorkspaceId,
+  PersistentMap,
+} from "../routing.js";
 
 describe("uriToWorkspaceId", () => {
   it("converts file:/// URI to file_ prefixed ID", () => {
@@ -65,5 +72,37 @@ describe("normalizeWorkspaceId", () => {
 
   it("replaces all colons (edge case: multiple drives is impossible but safe)", () => {
     expect(normalizeWorkspaceId("a:b:c")).toBe("a_3ab_3ac");
+  });
+});
+
+describe("PersistentMap", () => {
+  it("persists string entries and reloads them", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "porta-affinity-"));
+    const file = join(dir, "porta_affinity.json");
+
+    try {
+      const map = new PersistentMap(file, { persist: true });
+      map.set("cascade-a", "file_home_user_project");
+      map.set("cascade-b", "file_home_user_other");
+
+      expect(JSON.parse(await readFile(file, "utf-8"))).toEqual({
+        "cascade-a": "file_home_user_project",
+        "cascade-b": "file_home_user_other",
+      });
+
+      const reloaded = new PersistentMap(file, { persist: true });
+      expect(reloaded.get("cascade-a")).toBe("file_home_user_project");
+      expect(reloaded.get("cascade-b")).toBe("file_home_user_other");
+
+      reloaded.delete("cascade-a");
+      expect(JSON.parse(await readFile(file, "utf-8"))).toEqual({
+        "cascade-b": "file_home_user_other",
+      });
+
+      reloaded.clear();
+      expect(JSON.parse(await readFile(file, "utf-8"))).toEqual({});
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/proxy/src/discovery.ts
+++ b/packages/proxy/src/discovery.ts
@@ -150,7 +150,7 @@ async function discoverFromProcess(): Promise<LSInstance[]> {
  * Returns the first port that responds to GetWorkspaceInfos, or
  * falls back to the first candidate if none respond.
  */
-async function probeConnectRpcPort(
+export async function probeConnectRpcPort(
   candidates: number[],
   csrfToken: string,
 ): Promise<number> {
@@ -182,8 +182,7 @@ async function probeConnectRpcPort(
         res.on("end", () => {
           resolve(
             res.statusCode !== undefined &&
-              res.statusCode >= 200 &&
-              res.statusCode < 500,
+              res.statusCode === 200,
           );
         });
       });

--- a/packages/proxy/src/metadata.ts
+++ b/packages/proxy/src/metadata.ts
@@ -23,6 +23,13 @@ const CONVERSATIONS_DIR = join(
   "conversations",
 );
 
+const CONVERSATION_EXTENSIONS = [".pb", ".db"] as const;
+
+function conversationIdFromFilename(file: string): string | undefined {
+  const extension = CONVERSATION_EXTENSIONS.find((ext) => file.endsWith(ext));
+  return extension ? file.slice(0, -extension.length) : undefined;
+}
+
 /**
  * Build the metadata object that the LS requires on write RPCs.
  * Mirrors what the VS Code extension sends via MetadataProvider.
@@ -42,24 +49,30 @@ export async function getMetadata(
   return meta;
 }
 
-/** Scan disk for .pb conversation files not loaded in memory */
-export async function scanDiskConversations(): Promise<
+/** Scan disk for conversation files not loaded in memory */
+export async function scanDiskConversations(
+  conversationsDir = CONVERSATIONS_DIR,
+): Promise<
   { id: string; mtime: string }[]
 > {
   try {
-    const files = await readdir(CONVERSATIONS_DIR);
-    const results: { id: string; mtime: string }[] = [];
+    const files = await readdir(conversationsDir);
+    const results = new Map<string, { id: string; mtime: string }>();
     for (const file of files) {
-      if (!file.endsWith(".pb")) continue;
-      const id = file.replace(".pb", "");
+      const id = conversationIdFromFilename(file);
+      if (!id) continue;
       try {
-        const s = await stat(join(CONVERSATIONS_DIR, file));
-        results.push({ id, mtime: s.mtime.toISOString() });
+        const s = await stat(join(conversationsDir, file));
+        const mtime = s.mtime.toISOString();
+        const existing = results.get(id);
+        if (!existing || existing.mtime < mtime) {
+          results.set(id, { id, mtime });
+        }
       } catch {
-        results.push({ id, mtime: new Date().toISOString() });
+        results.set(id, { id, mtime: new Date().toISOString() });
       }
     }
-    return results;
+    return [...results.values()];
   } catch {
     return [];
   }

--- a/packages/proxy/src/origins.ts
+++ b/packages/proxy/src/origins.ts
@@ -5,10 +5,37 @@ const DEFAULT_ALLOWED_ORIGINS: AllowedOrigin[] = [
   /^https?:\/\/127\.0\.0\.1(:\d+)?$/,
 ];
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function originRegexForHost(host: string): RegExp | undefined {
+  const trimmed = host.trim();
+  if (!trimmed) return undefined;
+
+  const unwrapped =
+    trimmed.startsWith("[") && trimmed.endsWith("]")
+      ? trimmed.slice(1, -1)
+      : trimmed;
+  const originHost = unwrapped.includes(":")
+    ? `\\[${escapeRegExp(unwrapped)}\\]`
+    : escapeRegExp(unwrapped);
+
+  return new RegExp(`^https?:\\/\\/${originHost}(:\\d+)?$`);
+}
+
 export function getAllowedOrigins(
   env: NodeJS.ProcessEnv = process.env,
 ): AllowedOrigin[] {
   const allowedOrigins = [...DEFAULT_ALLOWED_ORIGINS];
+  const portaHostOrigin = env.PORTA_HOST
+    ? originRegexForHost(env.PORTA_HOST)
+    : undefined;
+
+  if (portaHostOrigin) {
+    allowedOrigins.push(portaHostOrigin);
+  }
+
   const configuredOrigins = env.PORTA_CORS_ORIGINS?.split(",")
     .map((origin) => origin.trim())
     .filter(Boolean);

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -191,6 +191,9 @@ export function registerConversationRoutes(app: Hono): void {
               const normalizedSummary =
                 withNormalizedConversationWorkspaces(summary);
               const wsUri = getPrimaryWorkspaceUri(normalizedSummary);
+              if (wsUri) {
+                conversationAffinity.set(id, uriToWorkspaceId(wsUri));
+              }
 
               // Skip conversations whose workspace isn't served by any scoped
               // running LS. Antigravity 2.x exposes a hub LS with no

--- a/packages/proxy/src/routing.ts
+++ b/packages/proxy/src/routing.ts
@@ -8,17 +8,121 @@
 import { LSDiscovery, type LSInstance } from "./discovery.js";
 import { getPrimaryWorkspaceUri } from "./metadata.js";
 import { RPCClient, RPCError } from "./rpc.js";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 
 // Module-scoped singletons — shared by all route modules
 export const discovery = new LSDiscovery();
 export const rpc = new RPCClient(discovery);
+
+const AFFINITY_FILE = join(
+  homedir(),
+  ".gemini",
+  "antigravity",
+  "porta_affinity.json",
+);
+
+function isTestRuntime(): boolean {
+  return process.env.NODE_ENV === "test" || process.env.VITEST === "true";
+}
+
+export class PersistentMap extends Map<string, string> {
+  private readonly persistEnabled: boolean;
+  private warned = false;
+
+  constructor(
+    private readonly filePath = AFFINITY_FILE,
+    options: { persist?: boolean } = {},
+  ) {
+    super();
+    this.persistEnabled = options.persist ?? !isTestRuntime();
+    this.load();
+  }
+
+  override set(key: string, value: string): this {
+    super.set(key, value);
+    this.persist();
+    return this;
+  }
+
+  override delete(key: string): boolean {
+    const deleted = super.delete(key);
+    if (deleted) this.persist();
+    return deleted;
+  }
+
+  override clear(): void {
+    if (this.size === 0) return;
+    super.clear();
+    this.persist();
+  }
+
+  private load(): void {
+    if (!this.persistEnabled || !existsSync(this.filePath)) return;
+
+    try {
+      const raw = readFileSync(this.filePath, "utf-8");
+      const parsed = JSON.parse(raw) as unknown;
+      const entries = Array.isArray(parsed)
+        ? parsed
+        : Object.entries(
+            parsed && typeof parsed === "object"
+              ? (parsed as Record<string, unknown>)
+              : {},
+          );
+
+      for (const entry of entries) {
+        if (!Array.isArray(entry)) continue;
+        const [key, value] = entry;
+        if (typeof key === "string" && typeof value === "string") {
+          super.set(key, value);
+        }
+      }
+    } catch (err) {
+      this.warnOnce("read", err);
+    }
+  }
+
+  private persist(): void {
+    if (!this.persistEnabled) return;
+
+    try {
+      mkdirSync(dirname(this.filePath), { recursive: true });
+      const tmpPath = `${this.filePath}.tmp`;
+      writeFileSync(
+        tmpPath,
+        `${JSON.stringify(Object.fromEntries(this), null, 2)}\n`,
+        "utf-8",
+      );
+      renameSync(tmpPath, this.filePath);
+    } catch (err) {
+      this.warnOnce("write", err);
+    }
+  }
+
+  private warnOnce(action: "read" | "write", err: unknown): void {
+    if (this.warned) return;
+    this.warned = true;
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[affinity] failed to ${action} ${this.filePath}: ${message}`,
+    );
+  }
+}
 
 /**
  * Conversation → owning workspaceId affinity cache.
  * Built from conversation metadata (workspaces[0].workspaceFolderAbsoluteUri)
  * and used to route RPC calls to the correct LS instance.
  */
-export const conversationAffinity = new Map<string, string>(); // cascadeId → workspaceId
+export const conversationAffinity = new PersistentMap(); // cascadeId → workspaceId
 export const conversationInstanceAffinity = new Map<string, LSInstance>(); // cascadeId → unscoped hub LS
 
 /** Convert a workspace URI to the LS workspaceId format. */

--- a/packages/web/src/__tests__/workspaceNames.test.ts
+++ b/packages/web/src/__tests__/workspaceNames.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAntigravityPlaygroundUri,
+  workspaceNameFromMetadata,
+  workspaceNameFromUri,
+} from "../utils/workspaceNames";
+
+describe("workspace name helpers", () => {
+  it("decodes URL-encoded path segments", () => {
+    expect(
+      workspaceNameFromUri(
+        "file:///c:/Users/deepk/Downloads/%E3%83%91%E3%83%BC%E3%83%84-20260315T145840Z-3-001",
+      ),
+    ).toBe("\u30d1\u30fc\u30c4-20260315T145840Z-3-001");
+  });
+
+  it("uses decoded repository names before URI segments", () => {
+    expect(
+      workspaceNameFromMetadata({
+        workspaceFolderAbsoluteUri: "file:///tmp/fallback",
+        repository: {
+          computedName:
+            "owner/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88",
+        },
+      }),
+    ).toBe("\u30d7\u30ed\u30b8\u30a7\u30af\u30c8");
+  });
+
+  it("detects Antigravity internal playground URIs", () => {
+    expect(
+      isAntigravityPlaygroundUri(
+        "file:///c:/Users/deepk/.gemini/antigravity/playground/harmonic-constellation",
+      ),
+    ).toBe(true);
+    expect(isAntigravityPlaygroundUri("file:///e:/Work/playground")).toBe(
+      false,
+    );
+  });
+
+  it("can collapse Antigravity playground workspaces into one display group", () => {
+    expect(
+      workspaceNameFromMetadata(
+        {
+          workspaceFolderAbsoluteUri:
+            "file:///c:/Users/deepk/.gemini/antigravity/playground/harmonic-constellation",
+        },
+        { collapseAntigravityPlayground: true },
+      ),
+    ).toBe("Antigravity Playground");
+    expect(
+      workspaceNameFromMetadata(
+        { workspaceFolderAbsoluteUri: "file:///e:/Work/playground" },
+        { collapseAntigravityPlayground: true },
+      ),
+    ).toBe("playground");
+  });
+
+  it("falls back to Others without workspace metadata", () => {
+    expect(workspaceNameFromMetadata(undefined)).toBe("Others");
+  });
+});

--- a/packages/web/src/components/ChatInput.tsx
+++ b/packages/web/src/components/ChatInput.tsx
@@ -184,7 +184,10 @@ export function ChatInput({
       let media: MediaAttachment[] | undefined;
       if (attachments.length > 0) {
         const prepared = await prepareAttachments(attachments.map((a) => a.file));
-        media = prepared.map(({ bytes: _bytes, ...attachment }) => attachment);
+        media = prepared.map((attachment) => ({
+          mimeType: attachment.mimeType,
+          inlineData: attachment.inlineData,
+        }));
       }
 
       onSend(trimmed || " ", model, media, plannerType);

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -23,8 +23,8 @@ import {
   CommandCard,
   CodeActionCard,
   FilePermissionCard,
-  getFilePermissionRequest,
 } from "./StepCards";
+import { getFilePermissionRequest } from "../utils/stepCards";
 import {
   IconCopy,
   IconCheck,

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useRef, useEffect, useCallback } from "react";
 import type { ConversationEntry } from "../hooks/useConversations";
 import { api } from "../api/client";
+import { workspaceNameFromMetadata } from "../utils/workspaceNames";
 import {
   IconPlus,
   IconSearch,
@@ -44,13 +45,9 @@ function relativeTime(iso: string): string {
 }
 
 function extractWorkspaceName(conv: ConversationEntry): string {
-  const ws = conv.summary.workspaces?.[0];
-  if (!ws) return "Others";
-  const repo = ws.repository?.computedName;
-  if (repo) return repo.split("/").pop() ?? repo;
-  const uri = ws.workspaceFolderAbsoluteUri;
-  if (uri) return uri.split("/").pop() ?? "Others";
-  return "Others";
+  return workspaceNameFromMetadata(conv.summary.workspaces?.[0], {
+    collapseAntigravityPlayground: true,
+  });
 }
 
 function isArchived(conv: ConversationEntry): boolean {
@@ -254,7 +251,9 @@ export function Sidebar({
         const next = { ...prev, [convId]: conv.summary.lastModifiedTime };
         try {
           localStorage.setItem("porta:seenAt", JSON.stringify(next));
-        } catch {}
+        } catch {
+          // localStorage can be unavailable in restricted browser contexts.
+        }
         return next;
       });
     },

--- a/packages/web/src/components/StepCards.tsx
+++ b/packages/web/src/components/StepCards.tsx
@@ -16,27 +16,6 @@ function basename(uriOrPath: string): string {
   return cleaned.split("/").pop() ?? cleaned;
 }
 
-/**
- * Extract a filePermissionRequest from any of the tool data fields
- * where the LS may embed it, or from the step's top-level field.
- *
- * The LS embeds filePermissionRequest in 6 step types:
- * CodeAction, ViewFile, ListDirectory, GrepSearch, ViewFileOutline, ViewCodeItem.
- */
-export function getFilePermissionRequest(
-  step: TrajectoryStep,
-): FilePermissionRequest | undefined {
-  return (
-    step.filePermissionRequest ??
-    step.viewFile?.filePermissionRequest ??
-    step.listDirectory?.filePermissionRequest ??
-    step.codeAction?.filePermissionRequest ??
-    step.grepSearch?.filePermissionRequest ??
-    step.viewFileOutline?.filePermissionRequest ??
-    step.viewCodeItem?.filePermissionRequest
-  );
-}
-
 /** Inline copy button for step cards */
 function StepCopyBtn({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);

--- a/packages/web/src/hooks/useAppResume.ts
+++ b/packages/web/src/hooks/useAppResume.ts
@@ -13,9 +13,6 @@ export function useAppResume(
   onResume: () => void,
   { enabled = true, dedupeMs = 250 }: UseAppResumeOptions = {},
 ): void {
-  const onResumeRef = useRef(onResume);
-  onResumeRef.current = onResume;
-
   const lastResumeAtRef = useRef<number>(-Infinity);
 
   useEffect(() => {
@@ -30,7 +27,7 @@ export function useAppResume(
       if (now - lastResumeAtRef.current < dedupeMs) return;
 
       lastResumeAtRef.current = now;
-      onResumeRef.current();
+      onResume();
     };
 
     const onVisibilityChange = () => {
@@ -48,5 +45,5 @@ export function useAppResume(
       window.removeEventListener("pageshow", emitResume);
       window.removeEventListener("focus", emitResume);
     };
-  }, [enabled, dedupeMs]);
+  }, [enabled, dedupeMs, onResume]);
 }

--- a/packages/web/src/hooks/useChatNotifications.ts
+++ b/packages/web/src/hooks/useChatNotifications.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { getFilePermissionRequest } from "../components/StepCards";
+import { getFilePermissionRequest } from "../utils/stepCards";
 import { showBrowserNotification } from "../utils/browserNotifications";
 import type { TrajectoryStep } from "../types";
 

--- a/packages/web/src/hooks/useDraftText.ts
+++ b/packages/web/src/hooks/useDraftText.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useCallback } from "react";
 
 /** Persist draft text per cascadeId across re-renders, HMR, and page reloads. */
 const DRAFT_PREFIX = "porta:draft:";
@@ -24,7 +24,9 @@ const draftStore = {
   delete(key: string): void {
     try {
       localStorage.removeItem(DRAFT_PREFIX + key);
-    } catch {}
+    } catch {
+      // localStorage can be unavailable in restricted browser contexts.
+    }
   },
 };
 
@@ -38,24 +40,18 @@ interface UseDraftTextResult {
  * Saves the current draft when switching away, loads the new draft when switching to.
  */
 export function useDraftText(activeId: string | null): UseDraftTextResult {
-  const [draftText, setDraftText] = useState("");
-  const activeIdRef = useRef(activeId);
-
-  useEffect(() => {
-    // Persist current draft before switching
-    if (activeIdRef.current) {
-      draftStore.set(activeIdRef.current, draftText);
-    }
-    activeIdRef.current = activeId;
-    setDraftText(activeId ? (draftStore.get(activeId) ?? "") : "");
-  }, [activeId]); // eslint-disable-line react-hooks/exhaustive-deps
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const draftKey = activeId ?? "__new__";
+  const draftText = activeId
+    ? (drafts[draftKey] ?? draftStore.get(activeId))
+    : (drafts[draftKey] ?? "");
 
   const handleDraftChange = useCallback(
     (text: string) => {
-      setDraftText(text);
+      setDrafts((prev) => ({ ...prev, [draftKey]: text }));
       if (activeId) draftStore.set(activeId, text);
     },
-    [activeId],
+    [activeId, draftKey],
   );
 
   return { draftText, handleDraftChange };

--- a/packages/web/src/hooks/useStepsStream.ts
+++ b/packages/web/src/hooks/useStepsStream.ts
@@ -63,6 +63,9 @@ export function useStepsStream(
   const endOffsetRef = useRef(0);
   // Monotonic generation counter — prevents stale responses from overwriting.
   const genRef = useRef(0);
+  const bumpGeneration = useCallback(() => {
+    genRef.current += 1;
+  }, []);
 
   // ── HTTP: initial load (latest N steps) ──
   const totalRef = useRef(totalStepCount ?? 0);
@@ -272,7 +275,7 @@ export function useStepsStream(
   // ── Lifecycle: fetch + connect ──
   useEffect(() => {
     mountedRef.current = true;
-    genRef.current++;
+    bumpGeneration();
     stepsRef.current = [];
     baseOffsetRef.current = 0;
     endOffsetRef.current = 0;
@@ -291,14 +294,14 @@ export function useStepsStream(
 
     return () => {
       mountedRef.current = false;
-      genRef.current++;
+      bumpGeneration();
       clearReconnectTimer();
       if (wsRef.current) {
         wsRef.current.close();
         wsRef.current = null;
       }
     };
-  }, [initialFetch, connectWs, clearReconnectTimer]);
+  }, [initialFetch, connectWs, clearReconnectTimer, bumpGeneration]);
 
   useEffect(() => {
     if (typeof document === "undefined") return;

--- a/packages/web/src/hooks/useWorkspaces.ts
+++ b/packages/web/src/hooks/useWorkspaces.ts
@@ -1,9 +1,13 @@
 import { useState, useEffect, useRef, useMemo } from "react";
 import { api } from "../api/client";
+import {
+  workspaceNameFromMetadata,
+  workspaceNameFromUri,
+} from "../utils/workspaceNames";
 
 /** Extract a short slug from a workspace URI: file:///home/user/work/porta → porta */
 function slugFromUri(uri: string): string {
-  return uri.replace("file://", "").split("/").pop() ?? uri;
+  return workspaceNameFromUri(uri);
 }
 
 /** Resolve a slug back to a full workspace URI using the workspace list. */
@@ -49,10 +53,7 @@ export function useWorkspaces(
       const ws = conv.summary.workspaces?.[0];
       if (!ws?.workspaceFolderAbsoluteUri) continue;
       const uri = ws.workspaceFolderAbsoluteUri;
-      const name =
-        ws.repository?.computedName?.split("/").pop() ??
-        uri.replace("file://", "").split("/").pop() ??
-        uri;
+      const name = workspaceNameFromMetadata(ws);
       fromConvs.set(uri, name);
     }
 
@@ -62,9 +63,7 @@ export function useWorkspaces(
       .then((data) => {
         const fromApi = (data.workspaceInfos ?? []).map((w) => ({
           uri: w.workspaceUri,
-          name:
-            w.workspaceUri.replace("file://", "").split("/").pop() ??
-            w.workspaceUri,
+          name: workspaceNameFromUri(w.workspaceUri),
         }));
         const merged = new Map<string, string>();
         for (const w of fromApi) merged.set(w.uri, w.name);

--- a/packages/web/src/transforms/stepsToMessages.ts
+++ b/packages/web/src/transforms/stepsToMessages.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage, TrajectoryStep } from "../types";
-import { getFilePermissionRequest } from "../components/StepCards";
+import { getFilePermissionRequest } from "../utils/stepCards";
 
 function textFromItems(items?: { text?: string }[]): string {
   if (!items) return "";

--- a/packages/web/src/utils/markdown.ts
+++ b/packages/web/src/utils/markdown.ts
@@ -38,14 +38,22 @@ function decodeHtmlEntities(text: string): string {
   );
 }
 
+function stripUnsafeUriChars(text: string): string {
+  return Array.from(text)
+    .filter((char) => {
+      const code = char.charCodeAt(0);
+      return code > 0x20 && (code < 0x7f || code > 0x9f);
+    })
+    .join("");
+}
+
 function isSafeUri(
   uri: string | null | undefined,
   allowedProtocols: ReadonlySet<string>,
 ): boolean {
   if (!uri) return false;
 
-  const normalized = decodeHtmlEntities(uri.trim())
-    .replace(/[\u0000-\u0020\u007f-\u009f]+/g, "")
+  const normalized = stripUnsafeUriChars(decodeHtmlEntities(uri.trim()))
     .toLowerCase();
 
   if (!normalized) return false;

--- a/packages/web/src/utils/stepCards.ts
+++ b/packages/web/src/utils/stepCards.ts
@@ -1,0 +1,22 @@
+import type { FilePermissionRequest, TrajectoryStep } from "../types";
+
+/**
+ * Extract a filePermissionRequest from any of the tool data fields
+ * where the LS may embed it, or from the step's top-level field.
+ *
+ * The LS embeds filePermissionRequest in 6 step types:
+ * CodeAction, ViewFile, ListDirectory, GrepSearch, ViewFileOutline, ViewCodeItem.
+ */
+export function getFilePermissionRequest(
+  step: TrajectoryStep,
+): FilePermissionRequest | undefined {
+  return (
+    step.filePermissionRequest ??
+    step.viewFile?.filePermissionRequest ??
+    step.listDirectory?.filePermissionRequest ??
+    step.codeAction?.filePermissionRequest ??
+    step.grepSearch?.filePermissionRequest ??
+    step.viewFileOutline?.filePermissionRequest ??
+    step.viewCodeItem?.filePermissionRequest
+  );
+}

--- a/packages/web/src/utils/workspaceNames.ts
+++ b/packages/web/src/utils/workspaceNames.ts
@@ -1,0 +1,53 @@
+import type { Workspace } from "../types";
+
+const ANTIGRAVITY_PLAYGROUND_NAME = "Antigravity Playground";
+
+interface WorkspaceNameOptions {
+  collapseAntigravityPlayground?: boolean;
+}
+
+function safeDecodeUriComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function lastPathSegment(uri: string): string {
+  const path = uri.replace(/^file:\/\//, "").replace(/\\/g, "/");
+  const segments = path.split("/").filter(Boolean);
+  return segments.at(-1) ?? uri;
+}
+
+export function workspaceNameFromUri(uri: string): string {
+  return safeDecodeUriComponent(lastPathSegment(uri));
+}
+
+export function isAntigravityPlaygroundUri(uri: string): boolean {
+  const normalized = safeDecodeUriComponent(uri)
+    .replace(/\\/g, "/")
+    .toLowerCase();
+  return normalized.includes("/.gemini/antigravity/playground/");
+}
+
+export function workspaceNameFromMetadata(
+  workspace?: Workspace,
+  options: WorkspaceNameOptions = {},
+): string {
+  if (!workspace) return "Others";
+
+  const uri = workspace.workspaceFolderAbsoluteUri;
+  if (
+    options.collapseAntigravityPlayground &&
+    uri &&
+    isAntigravityPlaygroundUri(uri)
+  ) {
+    return ANTIGRAVITY_PLAYGROUND_NAME;
+  }
+
+  const repoName = workspace.repository?.computedName?.split("/").pop();
+  if (repoName) return safeDecodeUriComponent(repoName);
+
+  return uri ? workspaceNameFromUri(uri) : "Others";
+}

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(({ mode }) => {
     ],
     envDir: repoRoot,
     server: {
+      host: proxyHost,
       proxy: {
         "/api": {
           target: toHttpOrigin(proxyHost, proxyPort),


### PR DESCRIPTION
## Summary
- Honor `PORTA_HOST` for Vite dev binding and proxy CORS/WS origin checks.
- Tighten Antigravity RPC port probing to require `200 OK` and support `.db` conversation discovery.
- Persist conversation workspace affinity and learn affinity before inactive workspace filtering.
- Clean up sidebar workspace names: decode URL-encoded names and collapse Antigravity internal playground workspaces into one group.
- Fix existing lint failures while touching nearby web code.

Fixes #75
Supersedes #80

## Tests
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `PORTA_E2E_CHROME_BIN="C:\Program Files\Google\Chrome\Application\chrome.exe" pnpm --filter @porta/web test:e2e`

## Manual Verification
- Restarted the proxy on `127.0.0.1:3170` and confirmed `/api/health` detects the running Antigravity language server.
- Confirmed `Origin: http://127.0.0.1:5176` is allowed by CORS.
- Confirmed `/api/conversations` returns 33 conversations, with 31 persisted affinity entries in `~/.gemini/antigravity/porta_affinity.json`.
- Verified Antigravity playground URIs collapse to `Antigravity Playground` while a real `E:/Work/playground` workspace remains separate.
