### PR TITLE
fix(proxy): redact errors and cap steps payload

### DIFF
--- a/packages/proxy/src/__tests__/conversations-route.test.ts
+++ b/packages/proxy/src/__tests__/conversations-route.test.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { LSInstance } from "../discovery.js";
+import { RPCError } from "../rpc.js";
 
 const mockGetInstances = vi.fn<() => Promise<LSInstance[]>>();
 const mockRpcCall = vi.fn<
@@ -9,6 +10,8 @@ const mockRpcCall = vi.fn<
 const mockScanDiskConversations = vi.fn<
   () => Promise<{ id: string; mtime: string }[]>
 >();
+const mockRpcForConversation = vi.fn();
+const mockGetStepCount = vi.fn();
 
 const conversationAffinity = new Map<string, string>();
 const conversationInstanceAffinity = new Map<string, LSInstance>();
@@ -22,6 +25,8 @@ vi.mock("../routing.js", async (importOriginal) => {
       getInstance: async () => (await mockGetInstances())[0] ?? null,
     },
     rpc: { call: mockRpcCall },
+    rpcForConversation: mockRpcForConversation,
+    getStepCount: mockGetStepCount,
     conversationAffinity,
     conversationInstanceAffinity,
   };
@@ -279,5 +284,114 @@ describe("POST /api/conversations", () => {
       }),
       hubLS,
     );
+  });
+});
+
+describe("GET /api/conversations/:id/steps", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    conversationAffinity.clear();
+    conversationInstanceAffinity.clear();
+    mockScanDiskConversations.mockResolvedValue([]);
+  });
+
+  it("caps limit to MAX_STEPS_LIMIT", async () => {
+    mockRpcForConversation.mockImplementation(async (method, _id, body) => {
+      if (method === "GetCascadeTrajectorySteps") {
+        return {
+          steps: Array.from({ length: 200 }, (_, i) => ({
+            id: body.stepOffset + i,
+          })),
+        };
+      }
+      return {};
+    });
+
+    const res = await app().request("/api/conversations/c-1/steps?limit=999");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.steps).toHaveLength(500);
+    expect(mockRpcForConversation).toHaveBeenCalledTimes(3);
+  });
+
+  it("caps oversized tail to MAX_STEPS_LIMIT", async () => {
+    const hubLS = makeInstance({ pid: 10 });
+    mockRpcForConversation.mockImplementation(async (method, _id, body) => {
+      if (method === "GetCascadeTrajectorySteps") {
+        return {
+          steps: Array.from({ length: 200 }, (_, i) => ({
+            id: body.stepOffset + i,
+          })),
+        };
+      }
+      return {};
+    });
+    mockGetStepCount.mockResolvedValue({ count: 2000, instance: hubLS });
+
+    const res = await app().request("/api/conversations/c-1/steps?tail=99999");
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.offset).toBe(1500);
+    expect(body.steps).toHaveLength(500);
+
+    expect(mockRpcForConversation).toHaveBeenCalledWith(
+      "GetCascadeTrajectorySteps",
+      "c-1",
+      expect.objectContaining({ stepOffset: 1500 }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("handles invalid tail gracefully", async () => {
+    const hubLS = makeInstance({ pid: 10 });
+    mockRpcForConversation.mockImplementation(async (method) => {
+      if (method === "GetCascadeTrajectorySteps") {
+        return { steps: [] };
+      }
+      return {};
+    });
+    mockGetStepCount.mockResolvedValue({ count: 2000, instance: hubLS });
+
+    const res = await app().request("/api/conversations/c-1/steps?tail=-50");
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.offset).toBe(1900);
+    expect(body.steps).toHaveLength(0);
+
+    expect(mockRpcForConversation).toHaveBeenCalledWith(
+      "GetCascadeTrajectorySteps",
+      "c-1",
+      expect.objectContaining({ stepOffset: 1900 }),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("caps oversized-step placeholders before allocating them", async () => {
+    mockRpcForConversation.mockRejectedValue(
+      new RPCError("step at offset 999999 larger than 4194304 byte limit", "internal"),
+    );
+
+    const res = await app().request("/api/conversations/c-1/steps?limit=20");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.steps).toHaveLength(20);
+  });
+
+  it("caps invalid UTF-8 placeholders before allocating them", async () => {
+    const hubLS = makeInstance({ pid: 10 });
+    mockGetStepCount.mockResolvedValue({ count: 999999, instance: hubLS });
+    mockRpcForConversation.mockRejectedValue(
+      new RPCError("invalid UTF-8 in step data", "internal"),
+    );
+
+    const res = await app().request("/api/conversations/c-1/steps?limit=20");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.steps).toHaveLength(20);
   });
 });

--- a/packages/proxy/src/__tests__/errors.edge.test.ts
+++ b/packages/proxy/src/__tests__/errors.edge.test.ts
@@ -21,7 +21,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("not found", "not_found"));
     expect(c.result).toEqual({
-      body: { error: "not found", code: "not_found" },
+      body: { error: "Internal Server Error", code: "not_found" },
       status: 502,
     });
   });
@@ -30,7 +30,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("denied", "permission_denied"));
     expect(c.result).toEqual({
-      body: { error: "denied", code: "permission_denied" },
+      body: { error: "Internal Server Error", code: "permission_denied" },
       status: 502,
     });
   });
@@ -90,7 +90,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     const msg = 'RPC failed: status=503, body="{"error":"timeout"}"';
     handleRPCError(c, new RPCError(msg, "unavailable"));
-    expect(c.result?.body).toEqual({ error: msg, code: "unavailable" });
+    expect(c.result?.body).toEqual({ error: "Internal Server Error", code: "unavailable" });
     expect(c.result?.status).toBe(503);
   });
 });

--- a/packages/proxy/src/__tests__/errors.edge.test.ts
+++ b/packages/proxy/src/__tests__/errors.edge.test.ts
@@ -39,7 +39,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, 42);
     expect(c.result).toEqual({
-      body: { error: "42" },
+      body: { error: "Internal Server Error" },
       status: 500,
     });
   });
@@ -48,7 +48,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, null);
     expect(c.result).toEqual({
-      body: { error: "null" },
+      body: { error: "Internal Server Error" },
       status: 500,
     });
   });
@@ -57,7 +57,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, undefined);
     expect(c.result).toEqual({
-      body: { error: "undefined" },
+      body: { error: "Internal Server Error" },
       status: 500,
     });
   });
@@ -72,7 +72,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, new CustomError());
     expect(c.result).toEqual({
-      body: { error: "custom error" },
+      body: { error: "Internal Server Error" },
       status: 500,
     });
   });
@@ -81,7 +81,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, { message: "object error" });
     expect(c.result).toEqual({
-      body: { error: "[object Object]" },
+      body: { error: "Internal Server Error" },
       status: 500,
     });
   });

--- a/packages/proxy/src/__tests__/errors.edge.test.ts
+++ b/packages/proxy/src/__tests__/errors.edge.test.ts
@@ -21,7 +21,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("not found", "not_found"));
     expect(c.result).toEqual({
-      body: { error: "Internal Server Error", code: "not_found" },
+      body: { error: "Upstream request failed", code: "not_found" },
       status: 502,
     });
   });
@@ -30,7 +30,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("denied", "permission_denied"));
     expect(c.result).toEqual({
-      body: { error: "Internal Server Error", code: "permission_denied" },
+      body: { error: "Upstream request failed", code: "permission_denied" },
       status: 502,
     });
   });
@@ -90,7 +90,7 @@ describe("handleRPCError — extended edge cases", () => {
     const c = mockContext();
     const msg = 'RPC failed: status=503, body="{"error":"timeout"}"';
     handleRPCError(c, new RPCError(msg, "unavailable"));
-    expect(c.result?.body).toEqual({ error: "Internal Server Error", code: "unavailable" });
+    expect(c.result?.body).toEqual({ error: "Language Server unavailable", code: "unavailable" });
     expect(c.result?.status).toBe(503);
   });
 });

--- a/packages/proxy/src/__tests__/errors.test.ts
+++ b/packages/proxy/src/__tests__/errors.test.ts
@@ -21,7 +21,7 @@ describe("handleRPCError", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("bad token", "unauthenticated"));
     expect(c.result).toEqual({
-      body: { error: "bad token", code: "unauthenticated" },
+      body: { error: "Internal Server Error", code: "unauthenticated" },
       status: 401,
     });
   });
@@ -30,7 +30,7 @@ describe("handleRPCError", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("no LS", "unavailable"));
     expect(c.result).toEqual({
-      body: { error: "no LS", code: "unavailable" },
+      body: { error: "Internal Server Error", code: "unavailable" },
       status: 503,
     });
   });
@@ -39,7 +39,7 @@ describe("handleRPCError", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("rpc fail", "internal"));
     expect(c.result).toEqual({
-      body: { error: "rpc fail", code: "internal" },
+      body: { error: "Internal Server Error", code: "internal" },
       status: 502,
     });
   });

--- a/packages/proxy/src/__tests__/errors.test.ts
+++ b/packages/proxy/src/__tests__/errors.test.ts
@@ -21,7 +21,7 @@ describe("handleRPCError", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("bad token", "unauthenticated"));
     expect(c.result).toEqual({
-      body: { error: "Internal Server Error", code: "unauthenticated" },
+      body: { error: "Authentication failed", code: "unauthenticated" },
       status: 401,
     });
   });
@@ -30,7 +30,7 @@ describe("handleRPCError", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("no LS", "unavailable"));
     expect(c.result).toEqual({
-      body: { error: "Internal Server Error", code: "unavailable" },
+      body: { error: "Language Server unavailable", code: "unavailable" },
       status: 503,
     });
   });
@@ -39,7 +39,7 @@ describe("handleRPCError", () => {
     const c = mockContext();
     handleRPCError(c, new RPCError("rpc fail", "internal"));
     expect(c.result).toEqual({
-      body: { error: "Internal Server Error", code: "internal" },
+      body: { error: "Upstream request failed", code: "internal" },
       status: 502,
     });
   });

--- a/packages/proxy/src/__tests__/errors.test.ts
+++ b/packages/proxy/src/__tests__/errors.test.ts
@@ -44,20 +44,20 @@ describe("handleRPCError", () => {
     });
   });
 
-  it("handles generic Error", () => {
+  it("handles generic Error by redacting details", () => {
     const c = mockContext();
     handleRPCError(c, new Error("something unexpected"));
     expect(c.result).toEqual({
-      body: { error: "something unexpected" },
+      body: { error: "Internal Server Error" },
       status: 500,
     });
   });
 
-  it("handles string errors", () => {
+  it("handles string errors by redacting details", () => {
     const c = mockContext();
     handleRPCError(c, "raw string error");
     expect(c.result).toEqual({
-      body: { error: "raw string error" },
+      body: { error: "Internal Server Error" },
       status: 500,
     });
   });

--- a/packages/proxy/src/errors.ts
+++ b/packages/proxy/src/errors.ts
@@ -6,16 +6,23 @@ import { RPCError } from "./rpc.js";
 
 export function handleRPCError(c: { json: Function }, err: unknown) {
   if (err instanceof RPCError) {
-    console.error("[Porta RPC Error]", err);
     const status =
       err.code === "unauthenticated"
         ? 401
         : err.code === "unavailable"
           ? 503
           : 502;
-    return c.json({ error: "Internal Server Error", code: err.code }, status);
+    const clientMessage =
+      err.code === "unauthenticated"
+        ? "Authentication failed"
+        : err.code === "unavailable"
+          ? "Language Server unavailable"
+          : "Upstream request failed";
+
+    console.error("[Porta Proxy RPC Error]", err);
+    return c.json({ error: clientMessage, code: err.code }, status);
   }
-  const message = err instanceof Error ? err.message : String(err);
+
   console.error("[Porta Proxy Error]", err);
   return c.json({ error: "Internal Server Error" }, 500);
 }

--- a/packages/proxy/src/errors.ts
+++ b/packages/proxy/src/errors.ts
@@ -15,5 +15,6 @@ export function handleRPCError(c: { json: Function }, err: unknown) {
     return c.json({ error: err.message, code: err.code }, status);
   }
   const message = err instanceof Error ? err.message : String(err);
-  return c.json({ error: message }, 500);
+  console.error("[Porta Proxy Error]", err);
+  return c.json({ error: "Internal Server Error" }, 500);
 }

--- a/packages/proxy/src/errors.ts
+++ b/packages/proxy/src/errors.ts
@@ -6,13 +6,14 @@ import { RPCError } from "./rpc.js";
 
 export function handleRPCError(c: { json: Function }, err: unknown) {
   if (err instanceof RPCError) {
+    console.error("[Porta RPC Error]", err);
     const status =
       err.code === "unauthenticated"
         ? 401
         : err.code === "unavailable"
           ? 503
           : 502;
-    return c.json({ error: err.message, code: err.code }, status);
+    return c.json({ error: "Internal Server Error", code: err.code }, status);
   }
   const message = err instanceof Error ? err.message : String(err);
   console.error("[Porta Proxy Error]", err);

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -33,6 +33,8 @@ import {
 import { messageTracker } from "../message-tracker.js";
 import { conversationSignals } from "../signals.js";
 
+const MAX_STEPS_LIMIT = 500;
+
 // ── Background warm-up for disk-only conversations ──
 
 /** Warm-up cache: cascadeId → timestamp when the warm-up was initiated. */
@@ -303,9 +305,14 @@ export function registerConversationRoutes(app: Hono): void {
   app.get("/api/conversations/:id/steps", async (c) => {
     const id = c.req.param("id");
     const offset = parseInt(c.req.query("offset") ?? "0", 10);
-    const limit = c.req.query("limit")
-      ? parseInt(c.req.query("limit")!, 10)
-      : undefined;
+    const limitParam = c.req.query("limit");
+    let limit = limitParam ? parseInt(limitParam, 10) : undefined;
+    if (limit !== undefined && (isNaN(limit) || limit <= 0)) {
+      limit = 100;
+    }
+    if (limit !== undefined) {
+      limit = Math.min(limit, MAX_STEPS_LIMIT);
+    }
 
     try {
       let resolvedOffset = offset;

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -339,9 +339,22 @@ export function registerConversationRoutes(app: Hono): void {
 
       // We need to fetch until we get what we came for, or we run out of steps.
       let currentOffset = resolvedOffset;
-      const targetCount =
+      let targetCount =
         limit ?? (stepCount ? stepCount - resolvedOffset : 100);
+      targetCount = Math.min(targetCount, MAX_STEPS_LIMIT);
       let consecutiveSkips = 0;
+
+      const pushPlaceholders = (count: number, reason: string) => {
+        const remainingTarget = targetCount - stepsArray.length;
+        const remainingSkips = MAX_SKIP - consecutiveSkips;
+        const placeholderCount = Math.max(
+          0,
+          Math.min(count, remainingTarget, remainingSkips),
+        );
+        for (let s = 0; s < placeholderCount; s++) {
+          stepsArray.push(placeholderStep(reason));
+        }
+      };
 
       while (stepsArray.length < targetCount) {
         try {
@@ -367,12 +380,10 @@ export function registerConversationRoutes(app: Hono): void {
           if (badOffset >= 0) {
             // Known oversized step — skip directly
             const skipCount = badOffset - currentOffset + 1;
-            for (let s = 0; s < skipCount; s++)
-              stepsArray.push(
-                placeholderStep(
-                  "Language Server: step exceeds 4MB protobuf limit",
-                ),
-              );
+            pushPlaceholders(
+              skipCount,
+              "Language Server: step exceeds 4MB protobuf limit",
+            );
             currentOffset = badOffset + 1;
             consecutiveSkips += skipCount;
             if (consecutiveSkips >= MAX_SKIP) break;
@@ -390,10 +401,10 @@ export function registerConversationRoutes(app: Hono): void {
               pinnedInstance,
             );
             const skipCount = nextValid - currentOffset;
-            for (let s = 0; s < skipCount; s++)
-              stepsArray.push(
-                placeholderStep("Language Server: invalid UTF-8 in step data"),
-              );
+            pushPlaceholders(
+              skipCount,
+              "Language Server: invalid UTF-8 in step data",
+            );
             console.log(
               `Skipping corrupted range [${currentOffset}, ${nextValid - 1}] (${skipCount} steps)`,
             );

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -328,7 +328,11 @@ export function registerConversationRoutes(app: Hono): void {
         pinnedInstance = sc.instance;
         if (sc.count > 0) {
           stepCount = sc.count;
-          const tailSize = parseInt(c.req.query("tail")!, 10);
+          let tailSize = parseInt(c.req.query("tail")!, 10);
+          if (isNaN(tailSize) || tailSize <= 0) {
+            tailSize = 100;
+          }
+          tailSize = Math.min(tailSize, MAX_STEPS_LIMIT);
           resolvedOffset = Math.max(0, stepCount - tailSize);
         }
       }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,10 @@ packages:
   - packages/proxy
   - packages/web
 
+allowBuilds:
+  '@swc/core': true
+  esbuild: true
+
 onlyBuiltDependencies:
   - '@swc/core'
   - esbuild


### PR DESCRIPTION
Replaces #77 with a branch name and title that satisfy PR lint.

This keeps the security hardening from #77 and the follow-up fixes from review:

1. **Redacted proxy errors**: generic thrown values return `Internal Server Error`; `RPCError` responses return whitelisted client-safe messages plus the upstream code.
2. **Bounded steps payloads**: `/api/conversations/:id/steps` caps effective response size across `limit`, `tail`, default target count, and recovery placeholders.
3. **Regression coverage**: tests cover generic thrown values, RPC redaction, oversized `limit`, oversized and invalid `tail`, and bounded placeholder expansion.

Validation performed locally after rebasing onto current `main`:

- `pnpm --filter @porta/proxy build`
- `pnpm --filter @porta/proxy test`