### PR TITLE
fix(proxy): scan active Antigravity app data conversations

### DIFF
--- a/packages/proxy/src/__tests__/conversations-route.test.ts
+++ b/packages/proxy/src/__tests__/conversations-route.test.ts
@@ -8,7 +8,7 @@ const mockRpcCall = vi.fn<
   (method: string, body: unknown, inst: LSInstance) => Promise<unknown>
 >();
 const mockScanDiskConversations = vi.fn<
-  () => Promise<{ id: string; mtime: string }[]>
+  (dirs?: string | string[]) => Promise<{ id: string; mtime: string }[]>
 >();
 const mockRpcForConversation = vi.fn();
 const mockGetStepCount = vi.fn();
@@ -135,6 +135,19 @@ describe("GET /api/conversations", () => {
 
     expect(body.trajectorySummaries["c-meta"].workspaces).toEqual([
       { workspaceFolderAbsoluteUri: "file:///home/user/project" },
+    ]);
+  });
+
+  it("scans the conversation directory for the running Antigravity app data dir", async () => {
+    const ideLS = makeInstance({ pid: 33, appDataDir: "antigravity-ide" });
+    mockGetInstances.mockResolvedValue([ideLS]);
+    mockRpcCall.mockResolvedValue({ trajectorySummaries: {} });
+
+    const res = await app().request("/api/conversations");
+
+    expect(res.status).toBe(200);
+    expect(mockScanDiskConversations).toHaveBeenCalledWith([
+      expect.stringMatching(/\/\.gemini\/antigravity-ide\/conversations$/),
     ]);
   });
 

--- a/packages/proxy/src/__tests__/metadata.test.ts
+++ b/packages/proxy/src/__tests__/metadata.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  conversationDirsForAppDataDirs,
   extractConversationWorkspaces,
   getMetadata,
   getPrimaryWorkspaceUri,
@@ -96,6 +97,20 @@ describe("conversation workspace metadata helpers", () => {
 });
 
 describe("scanDiskConversations", () => {
+  it("selects known Antigravity app-data conversation directories", () => {
+    const dirs = conversationDirsForAppDataDirs([
+      "antigravity-ide",
+      "unknown",
+      undefined,
+      "antigravity-ide",
+    ]);
+
+    expect(dirs).toHaveLength(1);
+    expect(dirs[0].replace(/\\/g, "/")).toMatch(
+      /\/\.gemini\/antigravity-ide\/conversations$/,
+    );
+  });
+
   it("scans .pb and .db conversations while ignoring SQLite sidecar files", async () => {
     const dir = await mkdtemp(join(tmpdir(), "porta-conversations-"));
     try {
@@ -137,6 +152,32 @@ describe("scanDiskConversations", () => {
       ]);
     } finally {
       await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("scans multiple app-data directories and deduplicates by newest mtime", async () => {
+    const oldDir = await mkdtemp(join(tmpdir(), "porta-conversations-old-"));
+    const newDir = await mkdtemp(join(tmpdir(), "porta-conversations-new-"));
+    try {
+      await writeFile(join(oldDir, "same.pb"), "");
+      await writeFile(join(newDir, "same.db"), "");
+      await writeFile(join(newDir, "new-only.db"), "");
+
+      const oldTime = new Date("2026-06-01T00:00:00.000Z");
+      const newTime = new Date("2026-06-03T00:00:00.000Z");
+      await utimes(join(oldDir, "same.pb"), oldTime, oldTime);
+      await utimes(join(newDir, "same.db"), newTime, newTime);
+      await utimes(join(newDir, "new-only.db"), newTime, newTime);
+
+      const results = await scanDiskConversations([oldDir, newDir]);
+
+      expect(results.sort((a, b) => a.id.localeCompare(b.id))).toEqual([
+        { id: "new-only", mtime: newTime.toISOString() },
+        { id: "same", mtime: newTime.toISOString() },
+      ]);
+    } finally {
+      await rm(oldDir, { recursive: true, force: true });
+      await rm(newDir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/proxy/src/__tests__/platform.test.ts
+++ b/packages/proxy/src/__tests__/platform.test.ts
@@ -57,7 +57,7 @@ describe("linux container detection", () => {
 describe("platform parsing helpers", () => {
   it("parses language server processes without hard-coding architecture", () => {
     const output = `
-  123 /Applications/Antigravity/language_server_macos_arm64 --csrf_token abc --workspace_id file_C:_Users_test_project --extension_server_port 1919 --lsp_port 2020
+  123 /Applications/Antigravity/language_server_macos_arm64 --csrf_token abc --workspace_id file_C:_Users_test_project --app_data_dir antigravity-ide --extension_server_port 1919 --lsp_port 2020
   456 /opt/antigravity/language_server_linux_x64 --csrf_token def --server_port 3030
   457 "C:\\Program Files\\Antigravity\\language_server_windows_x64.exe" --csrf_token "ghi" --server_port 4040 --workspace_id "file_C:_Users_test_project"
   789 /usr/bin/something_else --csrf_token nope
@@ -69,6 +69,7 @@ describe("platform parsing helpers", () => {
         pid: 123,
         csrfToken: "abc",
         workspaceId: "file_C:_Users_test_project",
+        appDataDir: "antigravity-ide",
         httpsPort: 0,
         httpPort: 1919,
         lspPort: 2020,

--- a/packages/proxy/src/discovery.ts
+++ b/packages/proxy/src/discovery.ts
@@ -29,20 +29,27 @@ export interface LSInstance {
   lspPort: number;
   csrfToken: string;
   workspaceId?: string;
+  appDataDir?: string;
   /** Derived from discovery source */
   source: "daemon" | "process";
 }
 
 const DAEMON_DIRS = [
-  join(homedir(), ".gemini", "antigravity", "daemon"),
-  join(homedir(), ".gemini", "antigravity-ide", "daemon"),
+  {
+    dir: join(homedir(), ".gemini", "antigravity", "daemon"),
+    appDataDir: "antigravity",
+  },
+  {
+    dir: join(homedir(), ".gemini", "antigravity-ide", "daemon"),
+    appDataDir: "antigravity-ide",
+  },
 ];
 const SERVICE_PREFIX = "exa.language_server_pb.LanguageServerService";
 
 async function discoverFromDaemon(): Promise<LSInstance[]> {
   const instances: LSInstance[] = [];
 
-  for (const daemonDir of DAEMON_DIRS) {
+  for (const { dir: daemonDir, appDataDir } of DAEMON_DIRS) {
     try {
       const files = await readdir(daemonDir);
       const lsFiles = files.filter(
@@ -63,6 +70,7 @@ async function discoverFromDaemon(): Promise<LSInstance[]> {
             httpPort: data.httpPort ?? 0,
             lspPort: data.lspPort ?? 0,
             csrfToken: data.csrfToken,
+            appDataDir,
             source: "daemon",
           });
         } catch {
@@ -86,6 +94,7 @@ async function discoverFromProcess(): Promise<LSInstance[]> {
       pid: number;
       csrfToken: string;
       workspaceId?: string;
+      appDataDir?: string;
       httpsPort: number;
       httpPort: number;
       lspPort: number;
@@ -102,6 +111,7 @@ async function discoverFromProcess(): Promise<LSInstance[]> {
           lspPort: candidate.lspPort,
           csrfToken: candidate.csrfToken,
           workspaceId: candidate.workspaceId,
+          appDataDir: candidate.appDataDir,
           source: "process",
         });
       } else {
@@ -109,6 +119,7 @@ async function discoverFromProcess(): Promise<LSInstance[]> {
           pid: candidate.pid,
           csrfToken: candidate.csrfToken,
           workspaceId: candidate.workspaceId,
+          appDataDir: candidate.appDataDir,
           httpsPort: 0,
           httpPort: candidate.httpPort,
           lspPort: candidate.lspPort,
@@ -137,6 +148,7 @@ async function discoverFromProcess(): Promise<LSInstance[]> {
             lspPort: pending.lspPort,
             csrfToken: pending.csrfToken,
             workspaceId: pending.workspaceId,
+            appDataDir: pending.appDataDir,
             source: "process",
           });
         }),
@@ -365,6 +377,7 @@ export async function discoverInstances(): Promise<LSInstance[]> {
       existing.httpPort = existing.httpPort || processInstance.httpPort;
       existing.lspPort = existing.lspPort || processInstance.lspPort;
       existing.csrfToken = existing.csrfToken || processInstance.csrfToken;
+      existing.appDataDir = existing.appDataDir || processInstance.appDataDir;
       if (!existing.workspaceId && processInstance.workspaceId) {
         existing.workspaceId = processInstance.workspaceId;
       }

--- a/packages/proxy/src/metadata.ts
+++ b/packages/proxy/src/metadata.ts
@@ -16,12 +16,13 @@ export interface ConversationWorkspaceMetadata {
   branchName?: string;
 }
 
-const CONVERSATIONS_DIR = join(
-  homedir(),
-  ".gemini",
-  "antigravity",
-  "conversations",
-);
+const KNOWN_APP_DATA_DIRS = ["antigravity", "antigravity-ide"] as const;
+
+function conversationDirForAppDataDir(appDataDir: string): string {
+  return join(homedir(), ".gemini", appDataDir, "conversations");
+}
+
+const CONVERSATIONS_DIRS = KNOWN_APP_DATA_DIRS.map(conversationDirForAppDataDir);
 
 const CONVERSATION_EXTENSIONS = [".pb", ".db"] as const;
 
@@ -51,31 +52,53 @@ export async function getMetadata(
 
 /** Scan disk for conversation files not loaded in memory */
 export async function scanDiskConversations(
-  conversationsDir = CONVERSATIONS_DIR,
+  conversationsDirs: string | string[] = CONVERSATIONS_DIRS,
 ): Promise<
   { id: string; mtime: string }[]
 > {
-  try {
-    const files = await readdir(conversationsDir);
-    const results = new Map<string, { id: string; mtime: string }>();
-    for (const file of files) {
-      const id = conversationIdFromFilename(file);
-      if (!id) continue;
-      try {
-        const s = await stat(join(conversationsDir, file));
-        const mtime = s.mtime.toISOString();
-        const existing = results.get(id);
-        if (!existing || existing.mtime < mtime) {
-          results.set(id, { id, mtime });
+  const dirs = Array.isArray(conversationsDirs)
+    ? conversationsDirs
+    : [conversationsDirs];
+  const results = new Map<string, { id: string; mtime: string }>();
+
+  for (const conversationsDir of dirs) {
+    try {
+      const files = await readdir(conversationsDir);
+      for (const file of files) {
+        const id = conversationIdFromFilename(file);
+        if (!id) continue;
+        try {
+          const s = await stat(join(conversationsDir, file));
+          const mtime = s.mtime.toISOString();
+          const existing = results.get(id);
+          if (!existing || existing.mtime < mtime) {
+            results.set(id, { id, mtime });
+          }
+        } catch {
+          results.set(id, { id, mtime: new Date().toISOString() });
         }
-      } catch {
-        results.set(id, { id, mtime: new Date().toISOString() });
       }
+    } catch {
+      // Conversation dir missing or unreadable
     }
-    return [...results.values()];
-  } catch {
-    return [];
   }
+
+  return [...results.values()];
+}
+
+export function conversationDirsForAppDataDirs(
+  appDataDirs: Iterable<string | undefined>,
+): string[] {
+  const known = new Set<string>(KNOWN_APP_DATA_DIRS);
+  const dirs = new Set<string>();
+
+  for (const appDataDir of appDataDirs) {
+    if (appDataDir && known.has(appDataDir)) {
+      dirs.add(conversationDirForAppDataDir(appDataDir));
+    }
+  }
+
+  return [...dirs];
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/proxy/src/platform/shared.ts
+++ b/packages/proxy/src/platform/shared.ts
@@ -70,11 +70,13 @@ export function parseCommandCandidate(
 
   const csrfToken = parseArgValue(args, "--csrf_token");
   if (!csrfToken) return undefined;
+  const appDataDir = parseArgValue(args, "--app_data_dir");
 
   return {
     pid,
     csrfToken,
     workspaceId: parseArgValue(args, "--workspace_id"),
+    ...(appDataDir ? { appDataDir } : {}),
     httpsPort: parsePort(args, "--server_port"),
     httpPort: parsePort(args, "--extension_server_port"),
     lspPort: parsePort(args, "--lsp_port"),

--- a/packages/proxy/src/platform/types.ts
+++ b/packages/proxy/src/platform/types.ts
@@ -2,6 +2,7 @@ export interface ProcessDiscoveryCandidate {
   pid: number;
   csrfToken: string;
   workspaceId?: string;
+  appDataDir?: string;
   httpsPort: number;
   httpPort: number;
   lspPort: number;

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -16,6 +16,7 @@ import {
 } from "../routing.js";
 import {
   extractConversationWorkspaces,
+  conversationDirsForAppDataDirs,
   getMetadata,
   getPrimaryWorkspaceUri,
   scanDiskConversations,
@@ -148,8 +149,6 @@ function warmUpDiskConversations(
               // This LS doesn't have it — try next
             }
           }
-          // No LS could load it — expire immediately so next poll retries
-          warmedAt.delete(cascadeId);
           failed++;
         }),
       );
@@ -244,8 +243,14 @@ export function registerConversationRoutes(app: Hono): void {
         // originally created it.
       }
 
-      // Also scan disk for all .pb files
-      const diskIds = await scanDiskConversations();
+      // Also scan disk for conversations in the app-data tree used by the
+      // running LS instances.
+      const diskConversationDirs = conversationDirsForAppDataDirs(
+        instances.map((inst) => inst.appDataDir),
+      );
+      const diskIds = await scanDiskConversations(
+        diskConversationDirs.length > 0 ? diskConversationDirs : undefined,
+      );
 
       // Merge: disk-only sessions get minimal placeholder metadata.
       // Actual workspace info will be resolved by the background warm-up below.

--- a/packages/proxy/src/ws.ts
+++ b/packages/proxy/src/ws.ts
@@ -4,7 +4,7 @@
  * Two states:
  *   IDLE   — No active agent run. A low-frequency heartbeat checks for
  *            externally-started or externally-completed updates.
- *   ACTIVE — Agent is running. 50ms serial polling for near-streaming UX.
+ *   ACTIVE — Agent is running. 200ms serial polling for near-streaming UX.
  *
  * Activation triggers (IDLE → ACTIVE):
  *   - conversationSignals "activate" (REST: SendMessage / StartCascade / Revert)
@@ -33,7 +33,7 @@ import {
 import { conversationSignals } from "./signals.js";
 
 /** Active polling interval (ms). */
-const ACTIVE_INTERVAL = 50;
+const ACTIVE_INTERVAL = 200;
 /** Idle polling interval (ms) for externally-originated updates. */
 const HEARTBEAT_INTERVAL = 5000;
 /** Transport keepalive interval (ms) for detecting dead idle sockets. */


### PR DESCRIPTION
## Summary
- detect the active Antigravity app data directory from daemon/process discovery
- scan conversations from the running LS app-data tree instead of always using the legacy `antigravity` directory
- avoid immediate repeated warm-up retries for conversations no running LS can load
- reduce active WebSocket polling from 50ms to 200ms to lower LS pressure during generation

## Verification
- `pnpm --filter @porta/proxy test`
- `pnpm --filter @porta/proxy build`
- `git diff --check`
- local `/api/conversations` returned 9 loaded conversations and `diskOnly=0` after warm-up

## Notes
- Existing uncommitted changes in `packages/web/functions/api/[[route]].ts`, `scripts/common.mjs`, and `scripts/dev-cloud.mjs` are intentionally not included in this PR.