### PR TITLE
chore(scripts): improve dev cloud env handling

### DIFF
--- a/scripts/common.mjs
+++ b/scripts/common.mjs
@@ -32,6 +32,34 @@ function unquote(value) {
   return value;
 }
 
+function stripInlineComment(value) {
+  let quote = null;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+
+    if (char === "\\" && quote === '"') {
+      index += 1;
+      continue;
+    }
+
+    if ((char === '"' || char === "'") && (!quote || quote === char)) {
+      quote = quote ? null : char;
+      continue;
+    }
+
+    if (
+      char === "#" &&
+      !quote &&
+      (index === 0 || /\s/.test(value[index - 1]))
+    ) {
+      return value.slice(0, index).trimEnd();
+    }
+  }
+
+  return value;
+}
+
 export function loadEnvFile(filePath = ".env") {
   const absPath = path.resolve(filePath);
   if (!existsSync(absPath)) return;
@@ -45,7 +73,7 @@ export function loadEnvFile(filePath = ".env") {
     if (separator < 1) continue;
 
     const key = line.slice(0, separator).trim();
-    const value = unquote(line.slice(separator + 1).trim());
+    const value = unquote(stripInlineComment(line.slice(separator + 1).trim()));
 
     if (process.env[key] === undefined) {
       process.env[key] = value;

--- a/scripts/dev-cloud.mjs
+++ b/scripts/dev-cloud.mjs
@@ -15,6 +15,13 @@ if (!tunnelName) {
   console.error("PORTA_TUNNEL_NAME is required in .env or the environment");
   process.exit(1);
 }
+const cloudflaredConfig = process.env.PORTA_CLOUDFLARED_CONFIG;
+const cloudflaredArgs = [
+  ...(cloudflaredConfig ? ["--config", cloudflaredConfig] : []),
+  "tunnel",
+  "run",
+  tunnelName,
+];
 
 const logsDir = ensureLogsDir();
 const runners = [
@@ -27,7 +34,7 @@ const runners = [
   spawnLoggedProcess(
     "tunnel",
     "cloudflared",
-    ["tunnel", "run", tunnelName],
+    cloudflaredArgs,
     path.join(logsDir, "tunnel.log"),
   ),
 ];


### PR DESCRIPTION
## Summary
- allow inline comments in values loaded from `.env` while preserving quoted `#` characters
- support `PORTA_CLOUDFLARED_CONFIG` for `pnpm dev:cloud` so named tunnels can use an explicit cloudflared config file

## Verification
- `node --check scripts/common.mjs`
- `node --check scripts/dev-cloud.mjs`
- `git diff --check`

## Notes
- Replaces #92 because the original branch name did not satisfy PR lint and GitHub keeps the original head ref on the existing PR.
- The Pages API route changes remain stashed for a later, safer pass.