### PR TITLE
fix(web): handle Antigravity ask-question prompts

### DIFF
--- a/packages/proxy/src/__tests__/conversations-route.test.ts
+++ b/packages/proxy/src/__tests__/conversations-route.test.ts
@@ -409,3 +409,62 @@ describe("GET /api/conversations/:id/steps", () => {
     expect(body.steps).toHaveLength(20);
   });
 });
+
+describe("POST /api/conversations/:id/ask-question", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    conversationAffinity.clear();
+    conversationInstanceAffinity.clear();
+    mockScanDiskConversations.mockResolvedValue([]);
+    mockRpcForConversation.mockResolvedValue({ ok: true });
+  });
+
+  it("forwards ask-question responses as a CascadeUserInteraction", async () => {
+    const responses = [
+      {
+        question: "Pick one",
+        selectedOptionIds: ["b"],
+      },
+    ];
+
+    const res = await app().request("/api/conversations/c-1/ask-question", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        trajectoryId: "traj-1",
+        stepIndex: 9,
+        responses,
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ ok: true });
+    expect(mockRpcForConversation).toHaveBeenCalledWith(
+      "HandleCascadeUserInteraction",
+      "c-1",
+      {
+        cascadeId: "c-1",
+        interaction: {
+          trajectoryId: "traj-1",
+          stepIndex: 9,
+          askQuestion: {
+            responses,
+            cancelled: false,
+          },
+        },
+      },
+    );
+  });
+
+  it("rejects requests without trajectory coordinates", async () => {
+    const res = await app().request("/api/conversations/c-1/ask-question", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ responses: [] }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(mockRpcForConversation).not.toHaveBeenCalled();
+  });
+});

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -710,6 +710,47 @@ export function registerConversationRoutes(app: Hono): void {
     }
   });
 
+  // ── Ask Question (Antigravity choice prompts) ──
+
+  app.post("/api/conversations/:id/ask-question", async (c) => {
+    const id = c.req.param("id");
+    try {
+      const body = await c.req.json();
+      const { trajectoryId, stepIndex, responses, cancelled } = body;
+
+      if (!trajectoryId || stepIndex === undefined) {
+        return c.json(
+          {
+            error: "Missing required fields: trajectoryId, stepIndex",
+          },
+          400,
+        );
+      }
+
+      const data = await rpcForConversation(
+        "HandleCascadeUserInteraction",
+        id,
+        {
+          cascadeId: id,
+          interaction: {
+            trajectoryId,
+            stepIndex: Number(stepIndex),
+            askQuestion: {
+              responses: Array.isArray(responses) ? responses : [],
+              cancelled: !!cancelled,
+            },
+          },
+        },
+      );
+
+      conversationSignals.emit("activate", id);
+
+      return c.json(data);
+    } catch (err) {
+      return handleRPCError(c, err);
+    }
+  });
+
   app.post("/api/conversations/:id/revert", async (c) => {
     const id = c.req.param("id");
     try {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -22,7 +22,7 @@ import { useChatActions } from "./hooks/useChatActions";
 import { useClientSettings } from "./hooks/useClientSettings";
 import { api } from "./api/client";
 import { isUnconfirmedOptimisticMessage } from "./utils/optimisticMessages";
-import type { HealthResponse, MediaAttachment } from "./types";
+import type { AskQuestionEntry, HealthResponse, MediaAttachment } from "./types";
 import type { PlannerType } from "./components/ChatInput";
 
 export default function App() {
@@ -192,6 +192,33 @@ function ChatView() {
     [activeId, refresh, triggerSoftRefresh],
   );
 
+  // ── Ask question response (Antigravity choice prompts) ──
+  const handleAskQuestion = useCallback(
+    async (
+      trajectoryId: string,
+      stepIndex: number,
+      responses: AskQuestionEntry[],
+      cancelled = false,
+    ) => {
+      if (!activeId) return;
+      try {
+        await api.askQuestion(
+          activeId,
+          trajectoryId,
+          stepIndex,
+          responses,
+          cancelled,
+        );
+        triggerSoftRefresh();
+        refresh();
+      } catch (err) {
+        console.error("Failed to respond to question:", err);
+        throw err;
+      }
+    },
+    [activeId, refresh, triggerSoftRefresh],
+  );
+
   // ── Navigate helpers ──
   const handleNew = useCallback(() => {
     navigate(`/${projectSlug ?? "unknown"}`);
@@ -287,6 +314,7 @@ function ChatView() {
             onRevert={handleRevert}
             onFilePermission={handleFilePermission}
             onCommandAction={handleCommandAction}
+            onAskQuestion={handleAskQuestion}
             onConfirmOptimistic={confirmOptimisticMessages}
             optimisticMessages={optimisticMessages}
             refreshKey={stepsRefreshKey}

--- a/packages/web/src/__tests__/CommandCard.test.tsx
+++ b/packages/web/src/__tests__/CommandCard.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
-import { CommandCard } from "../components/StepCards";
-import type { TrajectoryStep } from "../types";
+import { AskQuestionCard, CommandCard } from "../components/StepCards";
+import type { AskQuestionRequest, TrajectoryStep } from "../types";
 
 /** Helper: build a WAITING run-command step */
 function waitingStep(overrides: Partial<TrajectoryStep> = {}): TrajectoryStep {
@@ -111,5 +111,78 @@ describe("CommandCard", () => {
     render(<CommandCard step={step} />);
 
     expect(screen.getByText("npm test")).toBeInTheDocument();
+  });
+});
+
+function askQuestionStep(): TrajectoryStep {
+  return {
+    type: "CORTEX_STEP_TYPE_ASK_QUESTION",
+    status: "CORTEX_STEP_STATUS_WAITING",
+    metadata: {
+      sourceTrajectoryStepInfo: {
+        trajectoryId: "traj-1",
+        stepIndex: 9,
+      },
+    },
+  };
+}
+
+function askQuestionRequest(): AskQuestionRequest {
+  return {
+    questions: [
+      {
+        question: "Pick one",
+        options: [
+          { id: "a", text: "Alpha" },
+          { id: "b", text: "Beta" },
+        ],
+      },
+    ],
+  };
+}
+
+describe("AskQuestionCard", () => {
+  it("submits the selected option", async () => {
+    const onAskQuestion = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AskQuestionCard
+        step={askQuestionStep()}
+        askQuestionRequest={askQuestionRequest()}
+        fallbackStepIndex={3}
+        onAskQuestion={onAskQuestion}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Beta"));
+    await userEvent.click(screen.getByText("Submit"));
+
+    expect(onAskQuestion).toHaveBeenCalledWith("traj-1", 9, [
+      expect.objectContaining({
+        question: "Pick one",
+        selectedOptionIds: ["b"],
+      }),
+    ]);
+  });
+
+  it("marks questions skipped when skipping", async () => {
+    const onAskQuestion = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AskQuestionCard
+        step={askQuestionStep()}
+        askQuestionRequest={askQuestionRequest()}
+        fallbackStepIndex={3}
+        onAskQuestion={onAskQuestion}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Skip"));
+
+    expect(onAskQuestion).toHaveBeenCalledWith("traj-1", 9, [
+      expect.objectContaining({
+        question: "Pick one",
+        selectedOptionIds: [],
+        skipped: true,
+      }),
+    ]);
   });
 });

--- a/packages/web/src/__tests__/stepsToMessages.test.ts
+++ b/packages/web/src/__tests__/stepsToMessages.test.ts
@@ -201,6 +201,32 @@ describe("stepsToMessages", () => {
     expect(msgs[0].type).toBe("CORTEX_STEP_TYPE_CODE_ACTION");
   });
 
+  it("converts ask question to a system message with step data", () => {
+    const step: TrajectoryStep = {
+      type: "CORTEX_STEP_TYPE_ASK_QUESTION",
+      askQuestion: {
+        questions: [
+          {
+            question: "Pick one",
+            options: [
+              { id: "a", text: "Alpha" },
+              { id: "b", text: "Beta" },
+            ],
+          },
+        ],
+      },
+    };
+
+    const msgs = stepsToMessages([step]);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].role).toBe("system");
+    expect(msgs[0].type).toBe("CORTEX_STEP_TYPE_ASK_QUESTION");
+    expect(msgs[0].step?.askQuestion?.questions?.[0]?.question).toBe(
+      "Pick one",
+    );
+  });
+
   // ── Send command input (terminate) ──
 
   it("shows termination message", () => {

--- a/packages/web/src/api/client.ts
+++ b/packages/web/src/api/client.ts
@@ -132,6 +132,23 @@ export const api = {
       }),
     }),
 
+  askQuestion: (
+    cascadeId: string,
+    trajectoryId: string,
+    stepIndex: number,
+    responses: import("../types").AskQuestionEntry[],
+    cancelled = false,
+  ) =>
+    request(`/api/conversations/${cascadeId}/ask-question`, {
+      method: "POST",
+      body: JSON.stringify({
+        trajectoryId,
+        stepIndex,
+        responses,
+        cancelled,
+      }),
+    }),
+
   revert: (cascadeId: string, stepIndex: number, model?: string) =>
     request(`/api/conversations/${cascadeId}/revert`, {
       method: "POST",

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -20,11 +20,12 @@ import {
 import { renderMarkdown } from "../utils/markdown";
 import { MarkdownContent } from "./MarkdownContent";
 import {
+  AskQuestionCard,
   CommandCard,
   CodeActionCard,
   FilePermissionCard,
 } from "./StepCards";
-import { getFilePermissionRequest } from "../utils/stepCards";
+import { getAskQuestionRequest, getFilePermissionRequest } from "../utils/stepCards";
 import {
   IconCopy,
   IconCheck,
@@ -39,7 +40,7 @@ import {
   IconAlertTriangle,
   IconChevron,
 } from "./Icons";
-import type { ChatMessage } from "../types";
+import type { AskQuestionEntry, ChatMessage } from "../types";
 
 interface Props {
   cascadeId: string;
@@ -55,6 +56,12 @@ interface Props {
     trajectoryId: string,
     stepIndex: number,
     approved: boolean,
+  ) => Promise<void>;
+  onAskQuestion?: (
+    trajectoryId: string,
+    stepIndex: number,
+    responses: AskQuestionEntry[],
+    cancelled?: boolean,
   ) => Promise<void>;
   onConfirmOptimistic?: (ids: string[]) => void;
   optimisticMessages?: ChatMessage[];
@@ -233,6 +240,7 @@ function SystemMessage({
   msg,
   onFilePermission,
   onCommandAction,
+  onAskQuestion,
 }: {
   msg: ChatMessage;
   onFilePermission: (
@@ -246,6 +254,12 @@ function SystemMessage({
     trajectoryId: string,
     stepIndex: number,
     approved: boolean,
+  ) => Promise<void>;
+  onAskQuestion?: (
+    trajectoryId: string,
+    stepIndex: number,
+    responses: AskQuestionEntry[],
+    cancelled?: boolean,
   ) => Promise<void>;
 }) {
   const renderedContent = useMemo(
@@ -264,6 +278,21 @@ function SystemMessage({
               step={msg.step}
               permissionRequest={fpr}
               onFilePermission={onFilePermission}
+            />
+          </div>
+        );
+      }
+    }
+    if (msg.type === "CORTEX_STEP_TYPE_ASK_QUESTION") {
+      const askQuestion = getAskQuestionRequest(msg.step);
+      if (askQuestion) {
+        return (
+          <div className="message system">
+            <AskQuestionCard
+              step={msg.step}
+              askQuestionRequest={askQuestion}
+              fallbackStepIndex={msg.stepIndex}
+              onAskQuestion={onAskQuestion}
             />
           </div>
         );
@@ -508,6 +537,7 @@ export function ChatPanel({
   onRevert,
   onFilePermission,
   onCommandAction,
+  onAskQuestion,
   onConfirmOptimistic,
   optimisticMessages = [],
   refreshKey = 0,
@@ -817,6 +847,7 @@ export function ChatPanel({
                   msg={msg}
                   onFilePermission={onFilePermission}
                   onCommandAction={onCommandAction}
+                  onAskQuestion={onAskQuestion}
                 />
               </Fragment>
             );

--- a/packages/web/src/components/StepCards.tsx
+++ b/packages/web/src/components/StepCards.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   IconCopy,
   IconCheck,
@@ -7,8 +7,15 @@ import {
   IconFile,
   IconFileText,
   IconLock,
+  IconMessageCircle,
 } from "./Icons";
-import type { TrajectoryStep, FilePermissionRequest } from "../types";
+import type {
+  AskQuestionEntry,
+  AskQuestionOption,
+  AskQuestionRequest,
+  TrajectoryStep,
+  FilePermissionRequest,
+} from "../types";
 
 /** Extract file basename from a URI or path */
 function basename(uriOrPath: string): string {
@@ -116,6 +123,240 @@ export function FilePermissionCard({
             onClick={() => handleResponse(true, PERMISSION_SCOPE_CONVERSATION)}
           >
             Allow This Conversation
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Ask Question Card ──
+
+interface AskQuestionCardProps {
+  step: TrajectoryStep;
+  askQuestionRequest: AskQuestionRequest;
+  fallbackStepIndex: number;
+  onAskQuestion?: (
+    trajectoryId: string,
+    stepIndex: number,
+    responses: AskQuestionEntry[],
+    cancelled?: boolean,
+  ) => Promise<void>;
+}
+
+function optionId(
+  questionIndex: number,
+  optionIndex: number,
+  option: AskQuestionOption,
+): string {
+  return option.id ?? option.text ?? `${questionIndex}-${optionIndex}`;
+}
+
+function isWriteInOption(option: AskQuestionOption): boolean {
+  return /\b(other|custom|write)\b/i.test(option.text ?? "");
+}
+
+function responseFromQuestion(
+  question: AskQuestionEntry,
+  selectedOptionIds: string[],
+  writeInResponse: string,
+  skipped = false,
+): AskQuestionEntry {
+  return {
+    question: question.question,
+    options: question.options,
+    isMultiSelect: question.isMultiSelect,
+    selectedOptionIds,
+    ...(writeInResponse.trim()
+      ? { writeInResponse: writeInResponse.trim() }
+      : {}),
+    ...(skipped ? { skipped: true } : {}),
+  };
+}
+
+export function AskQuestionCard({
+  step,
+  askQuestionRequest,
+  fallbackStepIndex,
+  onAskQuestion,
+}: AskQuestionCardProps) {
+  const questions = useMemo(
+    () => askQuestionRequest.questions ?? [],
+    [askQuestionRequest.questions],
+  );
+  const [selectedByQuestion, setSelectedByQuestion] = useState<
+    Record<number, string[]>
+  >(() =>
+    Object.fromEntries(
+      questions.map((question, index) => [
+        index,
+        question.selectedOptionIds ?? [],
+      ]),
+    ),
+  );
+  const [writeIns, setWriteIns] = useState<Record<number, string>>(() =>
+    Object.fromEntries(
+      questions.map((question, index) => [
+        index,
+        question.writeInResponse ?? "",
+      ]),
+    ),
+  );
+  const [responded, setResponded] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isWaiting = step.status === "CORTEX_STEP_STATUS_WAITING";
+  const trajectoryId =
+    step.metadata?.sourceTrajectoryStepInfo?.trajectoryId ?? "";
+  const stepIndex =
+    step.metadata?.sourceTrajectoryStepInfo?.stepIndex ?? fallbackStepIndex;
+  const canRespond =
+    isWaiting && !responded && !!onAskQuestion && !!trajectoryId;
+
+  const hasAnswer =
+    questions.length > 0 &&
+    questions.every((_, index) => {
+      const selected = selectedByQuestion[index] ?? [];
+      const writeIn = writeIns[index]?.trim() ?? "";
+      return selected.length > 0 || writeIn.length > 0;
+    });
+
+  const setOptionSelected = (
+    questionIndex: number,
+    option: AskQuestionOption,
+    optionIndex: number,
+    isMultiSelect: boolean,
+  ) => {
+    const id = optionId(questionIndex, optionIndex, option);
+    setSelectedByQuestion((prev) => {
+      const existing = prev[questionIndex] ?? [];
+      if (!isMultiSelect) {
+        return { ...prev, [questionIndex]: [id] };
+      }
+      return {
+        ...prev,
+        [questionIndex]: existing.includes(id)
+          ? existing.filter((value) => value !== id)
+          : [...existing, id],
+      };
+    });
+  };
+
+  const buildResponses = (skipped = false): AskQuestionEntry[] =>
+    questions.map((question, index) =>
+      responseFromQuestion(
+        question,
+        skipped ? [] : (selectedByQuestion[index] ?? []),
+        skipped ? "" : (writeIns[index] ?? ""),
+        skipped,
+      ),
+    );
+
+  const handleSubmit = async (skipped = false) => {
+    if (!onAskQuestion || !canRespond || submitting) return;
+    setSubmitting(true);
+    setResponded(true);
+    try {
+      await onAskQuestion(trajectoryId, stepIndex, buildResponses(skipped));
+    } catch {
+      setResponded(false);
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className={`chat-block step-card ask-question-card ${responded ? "cmd-ok" : isWaiting ? "cmd-wait" : ""}`}
+    >
+      <div className="step-card-header ask-question-header">
+        <span className="step-card-icon">
+          <IconMessageCircle size={12} />
+        </span>
+        <span className="step-card-desc">Input requested</span>
+      </div>
+      <div className="ask-question-body">
+        {questions.map((question, questionIndex) => {
+          const options = question.options ?? [];
+          const selected = selectedByQuestion[questionIndex] ?? [];
+          const showWriteIn =
+            options.length === 0 ||
+            options.some((option, optionIndex) => {
+              const id = optionId(questionIndex, optionIndex, option);
+              return selected.includes(id) && isWriteInOption(option);
+            });
+
+          return (
+            <div className="ask-question" key={questionIndex}>
+              {question.question && (
+                <div className="ask-question-text">{question.question}</div>
+              )}
+              {options.length > 0 && (
+                <div className="ask-question-options">
+                  {options.map((option, optionIndex) => {
+                    const id = optionId(questionIndex, optionIndex, option);
+                    const active = selected.includes(id);
+                    return (
+                      <button
+                        key={id}
+                        type="button"
+                        className={`ask-question-option ${active ? "active" : ""}`}
+                        disabled={!canRespond}
+                        onClick={() =>
+                          setOptionSelected(
+                            questionIndex,
+                            option,
+                            optionIndex,
+                            !!question.isMultiSelect,
+                          )
+                        }
+                      >
+                        <span className="ask-question-option-index">
+                          {optionIndex + 1}
+                        </span>
+                        <span className="ask-question-option-text">
+                          {option.text ?? id}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+              {showWriteIn && (
+                <textarea
+                  className="ask-question-write-in"
+                  aria-label="Custom answer"
+                  value={writeIns[questionIndex] ?? ""}
+                  disabled={!canRespond}
+                  onChange={(event) =>
+                    setWriteIns((prev) => ({
+                      ...prev,
+                      [questionIndex]: event.target.value,
+                    }))
+                  }
+                  rows={2}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {canRespond && (
+        <div className="step-card-actions ask-question-actions">
+          <button
+            className="approve-btn ask-question-btn skip"
+            type="button"
+            disabled={submitting}
+            onClick={() => void handleSubmit(true)}
+          >
+            Skip
+          </button>
+          <button
+            className="approve-btn ask-question-btn submit"
+            type="button"
+            disabled={!hasAnswer || submitting}
+            onClick={() => void handleSubmit(false)}
+          >
+            Submit
           </button>
         </div>
       )}

--- a/packages/web/src/styles/step-cards.css
+++ b/packages/web/src/styles/step-cards.css
@@ -170,6 +170,166 @@
   border-color: var(--accent-hover);
 }
 
+/* ── Ask Question Card ── */
+
+.ask-question-header {
+  cursor: default;
+}
+
+.ask-question-header:hover {
+  background: transparent;
+}
+
+.ask-question-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 0 14px 12px;
+}
+
+.ask-question {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.ask-question-text {
+  color: var(--text-primary);
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ask-question-options {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.ask-question-option {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  color: var(--text-secondary);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast),
+    color var(--transition-fast);
+}
+
+.ask-question-option:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-focus);
+}
+
+.ask-question-option.active {
+  background: rgb(var(--c-accent) / 0.12);
+  color: var(--text-primary);
+  border-color: rgb(var(--c-accent) / 0.45);
+}
+
+.ask-question-option:disabled {
+  cursor: default;
+  opacity: 0.75;
+}
+
+.ask-question-option-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  background: var(--bg-tertiary);
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.ask-question-option.active .ask-question-option-index {
+  background: rgb(var(--c-accent) / 0.22);
+  color: var(--text-accent);
+}
+
+.ask-question-option-text {
+  min-width: 0;
+  font-size: 12.5px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ask-question-write-in {
+  width: 100%;
+  resize: vertical;
+  min-height: 58px;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  line-height: 1.45;
+  outline: none;
+}
+
+.ask-question-write-in:focus {
+  border-color: rgb(var(--c-accent) / 0.55);
+  box-shadow: 0 0 0 2px rgb(var(--c-accent) / 0.16);
+}
+
+.ask-question-actions {
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.ask-question-btn {
+  font-size: 12px;
+  padding: 6px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-default);
+}
+
+.ask-question-btn.skip {
+  background: transparent;
+  color: var(--text-tertiary);
+  border-color: transparent;
+}
+
+.ask-question-btn.skip:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text-secondary);
+}
+
+.ask-question-btn.submit {
+  background: var(--accent);
+  color: var(--text-on-solid);
+  border-color: var(--accent);
+}
+
+.ask-question-btn.submit:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.ask-question-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 /* ── Command Action Card ── */
 
 .command-action-bar {

--- a/packages/web/src/transforms/stepsToMessages.ts
+++ b/packages/web/src/transforms/stepsToMessages.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage, TrajectoryStep } from "../types";
-import { getFilePermissionRequest } from "../utils/stepCards";
+import { getAskQuestionRequest, getFilePermissionRequest } from "../utils/stepCards";
 
 function textFromItems(items?: { text?: string }[]): string {
   if (!items) return "";
@@ -25,6 +25,22 @@ export function stepsToMessages(steps: TrajectoryStep[]): ChatMessage[] {
         content: "",
         stepIndex: i,
         type: "CORTEX_STEP_TYPE_FILE_PERMISSION",
+        step,
+      });
+      continue;
+    }
+
+    const askQuestion = getAskQuestionRequest(step);
+    if (
+      askQuestion &&
+      (type === "CORTEX_STEP_TYPE_ASK_QUESTION" ||
+        step.requestedInteraction?.askQuestion)
+    ) {
+      messages.push({
+        role: "system",
+        content: "",
+        stepIndex: i,
+        type: "CORTEX_STEP_TYPE_ASK_QUESTION",
         step,
       });
       continue;

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -58,6 +58,42 @@ export interface FilePermissionRequest {
   isDirectory?: boolean;
 }
 
+// ── Ask Question ──
+
+export interface AskQuestionOption {
+  id?: string;
+  text?: string;
+}
+
+export interface AskQuestionEntry {
+  question?: string;
+  options?: AskQuestionOption[];
+  isMultiSelect?: boolean;
+  selectedOptionIds?: string[];
+  writeInResponse?: string;
+  skipped?: boolean;
+}
+
+export interface AskQuestionRequest {
+  questions?: AskQuestionEntry[];
+}
+
+export interface AskQuestionInteraction {
+  responses?: AskQuestionEntry[];
+  cancelled?: boolean;
+}
+
+export interface RequestedInteractionData {
+  askQuestion?: AskQuestionRequest;
+}
+
+export interface CompletedInteractionData {
+  request?: RequestedInteractionData;
+  response?: {
+    askQuestion?: AskQuestionInteraction;
+  };
+}
+
 // ── Trajectory Steps ──
 
 export interface StepsResponse {
@@ -88,6 +124,9 @@ export interface TrajectoryStep {
   viewCodeItem?: ViewCodeItemData;
   listDirectory?: ListDirectoryData;
   find?: FindData;
+  askQuestion?: AskQuestionRequest;
+  requestedInteraction?: RequestedInteractionData;
+  completedInteractions?: CompletedInteractionData[];
   /** File permission request can appear on any tool step */
   filePermissionRequest?: FilePermissionRequest;
 }

--- a/packages/web/src/utils/stepCards.ts
+++ b/packages/web/src/utils/stepCards.ts
@@ -1,4 +1,8 @@
-import type { FilePermissionRequest, TrajectoryStep } from "../types";
+import type {
+  AskQuestionRequest,
+  FilePermissionRequest,
+  TrajectoryStep,
+} from "../types";
 
 /**
  * Extract a filePermissionRequest from any of the tool data fields
@@ -19,4 +23,13 @@ export function getFilePermissionRequest(
     step.viewFileOutline?.filePermissionRequest ??
     step.viewCodeItem?.filePermissionRequest
   );
+}
+
+export function getAskQuestionRequest(
+  step: TrajectoryStep,
+): AskQuestionRequest | undefined {
+  const request = step.askQuestion ?? step.requestedInteraction?.askQuestion;
+  return request?.questions && request.questions.length > 0
+    ? request
+    : undefined;
 }


### PR DESCRIPTION
## Summary
- render Antigravity ask-question interactions as actionable Porta step cards
- forward selected option/write-in responses through the proxy via CascadeUserInteraction
- add coverage for message conversion, ask-question card behavior, and proxy routing

Closes #76

## Testing
- git diff --check
- pnpm --filter @porta/web test -- --run src/__tests__/stepsToMessages.test.ts src/__tests__/CommandCard.test.tsx
- pnpm --filter @porta/proxy test -- src/__tests__/conversations-route.test.ts
- pnpm --filter @porta/web lint
- pnpm --filter @porta/web build
- pnpm --filter @porta/proxy build