### PR TITLE
feat(web): sort workspaces by recency and expose workspace-less conversations

### DIFF
--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -45,9 +45,10 @@ function relativeTime(iso: string): string {
 }
 
 function extractWorkspaceName(conv: ConversationEntry): string {
-  return workspaceNameFromMetadata(conv.summary.workspaces?.[0], {
+  const name = workspaceNameFromMetadata(conv.summary.workspaces?.[0], {
     collapseAntigravityPlayground: true,
   });
+  return name === "Others" ? "No Workspace" : name;
 }
 
 function isArchived(conv: ConversationEntry): boolean {
@@ -142,7 +143,6 @@ export function Sidebar({
     }
 
     return Array.from(map.entries())
-      .filter(([name]) => name !== "Others") // Hide workspace-less conversations
       .map(([name, convs]) => {
         // Sort within group: running first, then by lastModifiedTime desc
         convs.sort((a, b) => {
@@ -163,6 +163,10 @@ export function Sidebar({
         };
       })
       .sort((a, b) => {
+        // Keep "No Workspace" group at the bottom
+        if (a.name === "No Workspace" && b.name !== "No Workspace") return 1;
+        if (a.name !== "No Workspace" && b.name === "No Workspace") return -1;
+
         const aHasActive = a.conversations.some((c) => !isArchived(c));
         const bHasActive = b.conversations.some((c) => !isArchived(c));
         if (aHasActive !== bHasActive) return aHasActive ? -1 : 1;
@@ -177,6 +181,7 @@ export function Sidebar({
             new Date(c.summary.lastModifiedTime).getTime(),
           ),
         );
+
         return bTime - aTime;
       });
   }, [conversations]);

--- a/packages/web/src/hooks/useWorkspaces.ts
+++ b/packages/web/src/hooks/useWorkspaces.ts
@@ -21,6 +21,7 @@ function uriFromSlug(
 interface ConversationEntry {
   id: string;
   summary: {
+    lastModifiedTime?: string;
     workspaces?: {
       workspaceFolderAbsoluteUri?: string;
       repository?: { computedName?: string };
@@ -47,14 +48,24 @@ export function useWorkspaces(
   const wsInitialized = useRef(false);
 
   useEffect(() => {
-    // Collect from conversations
+    // Collect from conversations and track their last modified time
     const fromConvs = new Map<string, string>();
+    const workspaceRecency = new Map<string, number>();
+
     for (const conv of conversations) {
       const ws = conv.summary.workspaces?.[0];
       if (!ws?.workspaceFolderAbsoluteUri) continue;
       const uri = ws.workspaceFolderAbsoluteUri;
       const name = workspaceNameFromMetadata(ws);
       fromConvs.set(uri, name);
+
+      const time = conv.summary.lastModifiedTime
+        ? new Date(conv.summary.lastModifiedTime).getTime()
+        : 0;
+      const existing = workspaceRecency.get(uri) ?? 0;
+      if (time > existing) {
+        workspaceRecency.set(uri, time);
+      }
     }
 
     // Collect from LS API
@@ -65,17 +76,38 @@ export function useWorkspaces(
           uri: w.workspaceUri,
           name: workspaceNameFromUri(w.workspaceUri),
         }));
+
+        // Assign a high score (current time) to active workspaces that don't have past conversations
+        // so that they stay at the very top of the list.
+        for (const w of fromApi) {
+          if (!workspaceRecency.has(w.uri)) {
+            workspaceRecency.set(w.uri, Date.now());
+          }
+        }
+
         const merged = new Map<string, string>();
         for (const w of fromApi) merged.set(w.uri, w.name);
         for (const [uri, name] of fromConvs) {
           if (!merged.has(uri)) merged.set(uri, name);
         }
+
         const list = Array.from(merged, ([uri, name]) => ({ uri, name }));
+        list.sort((a, b) => {
+          const timeA = workspaceRecency.get(a.uri) ?? 0;
+          const timeB = workspaceRecency.get(b.uri) ?? 0;
+          return timeB - timeA;
+        });
+
         setWorkspaces(list);
         wsInitialized.current = true;
       })
       .catch(() => {
         const list = Array.from(fromConvs, ([uri, name]) => ({ uri, name }));
+        list.sort((a, b) => {
+          const timeA = workspaceRecency.get(a.uri) ?? 0;
+          const timeB = workspaceRecency.get(b.uri) ?? 0;
+          return timeB - timeA;
+        });
         setWorkspaces(list);
         wsInitialized.current = true;
       });


### PR DESCRIPTION
### Summary
This PR improves the usability of the remote web UI by sorting the workspace list chronologically and ensuring all conversations (including those without active workspaces) are visible in the sidebar.

### Rationale & Changes

1. **Chronological Sorting of Workspaces (`useWorkspaces.ts`)**
   - **Problem:** When there are many historical conversations, finding recently used workspaces in the dropdown was difficult because the list had no order.
   - **Solution:** Modified `useWorkspaces` to track the `lastModifiedTime` of each workspace's conversations and sort the list so that the most recently used workspaces appear first.
   - **Active Workspace Priority:** Active workspaces (returned from the LS API) that do not have conversation history yet are assigned a high score (`Date.now()`) to keep them at the top of the list.

2. **Expose Workspace-less Conversations (`Sidebar.tsx`)**
   - **Problem:** Conversations without workspaces (or those still in the "disk-only/unloaded" warm-up phase) were grouped into `"Others"`, which was completely filtered out and hidden in the sidebar (`.filter(([name]) => name !== "Others")`). This made it impossible to access or resume these archived conversations.
   - **Solution:** 
     - Renamed the `"Others"` category to `"No Workspace"`.
     - Removed the filter so these conversations are accessible.
     - Sorted the `"No Workspace"` group at the bottom of the sidebar list so active workspace folders retain visual priority.

### Verification
- Frontend builds successfully (`tsc -b && vite build`).
- Confirmed that the workspace dropdown is sorted correctly by conversation recency.
- Confirmed that previously hidden workspace-less/disk-only conversations now appear under the "No Workspace" group at the bottom of the sidebar.