### PR TITLE
perf(proxy): limit total conversations and prioritize recent ones to prevent LS thrashing

### DIFF
--- a/packages/proxy/src/__tests__/conversations-route.test.ts
+++ b/packages/proxy/src/__tests__/conversations-route.test.ts
@@ -193,6 +193,81 @@ describe("GET /api/conversations", () => {
       ],
     });
   });
+
+  it("caps total returned conversations to 100 when LS returns > 100", async () => {
+    const hubLS = makeInstance({ pid: 1, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+
+    // Generate 105 summaries with different lastModifiedTime values
+    const baseTime = new Date("2026-06-01T00:00:00.000Z").getTime();
+    const trajectorySummaries: Record<string, any> = {};
+    for (let i = 1; i <= 105; i++) {
+      const timeStr = new Date(baseTime + i * 1000).toISOString();
+      trajectorySummaries[`c-${i}`] = {
+        summary: `Conv ${i}`,
+        stepCount: 5,
+        lastModifiedTime: timeStr,
+        workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/project" }],
+      };
+    }
+
+    mockRpcCall.mockResolvedValue({ trajectorySummaries });
+
+    const res = await app().request("/api/conversations");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    const keys = Object.keys(body.trajectorySummaries);
+    expect(keys).toHaveLength(100);
+
+    // The returned list should exclude the oldest ones (c-1 to c-5)
+    // and include the 100 newest ones (c-6 to c-105)
+    expect(keys).not.toContain("c-1");
+    expect(keys).not.toContain("c-5");
+    expect(keys).toContain("c-6");
+    expect(keys).toContain("c-105");
+  });
+
+  it("prioritizes a newer disk conversation and evicts older LS conversations when combined limit is exceeded", async () => {
+    const hubLS = makeInstance({ pid: 1, workspaceId: undefined });
+    mockGetInstances.mockResolvedValue([hubLS]);
+
+    // LS returns 100 older conversations
+    const trajectorySummaries: Record<string, any> = {};
+    for (let i = 1; i <= 100; i++) {
+      trajectorySummaries[`c-${i}`] = {
+        summary: `Conv ${i}`,
+        stepCount: 5,
+        lastModifiedTime: "2026-06-01T00:00:00.000Z",
+        workspaces: [{ workspaceFolderAbsoluteUri: "file:///home/user/project" }],
+      };
+    }
+    mockRpcCall.mockImplementation(async (method) => {
+      if (method === "GetAllCascadeTrajectories") {
+        return { trajectorySummaries };
+      }
+      return { steps: [] };
+    });
+
+    // Disk scan finds 1 newer conversation
+    mockScanDiskConversations.mockResolvedValue([
+      { id: "c-new-disk", mtime: "2026-06-02T00:00:00.000Z" },
+    ]);
+
+    const res = await app().request("/api/conversations");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    const keys = Object.keys(body.trajectorySummaries);
+    expect(keys).toHaveLength(100);
+
+    // The newer disk-only conversation must be included
+    expect(keys).toContain("c-new-disk");
+    expect(body.trajectorySummaries["c-new-disk"]).toMatchObject({
+      _diskOnly: true,
+      lastModifiedTime: "2026-06-02T00:00:00.000Z",
+    });
+  });
 });
 
 describe("POST /api/conversations", () => {

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -251,11 +251,20 @@ export function registerConversationRoutes(app: Hono): void {
       const diskIds = await scanDiskConversations(
         diskConversationDirs.length > 0 ? diskConversationDirs : undefined,
       );
+      // Sort diskIds by mtime descending so we prioritize warming up/displaying the most recent ones
+      diskIds.sort((a, b) => new Date(b.mtime).getTime() - new Date(a.mtime).getTime());
 
       // Merge: disk-only sessions get minimal placeholder metadata.
       // Actual workspace info will be resolved by the background warm-up below.
+      // We limit the total number of conversations returned to prevent UI lag
+      // and protect the LS from infinite warm-up eviction loops.
       const diskOnlyIds: string[] = [];
+      const MAX_TOTAL_CONVERSATIONS = 100;
+
       for (const diskId of diskIds) {
+        if (Object.keys(merged).length >= MAX_TOTAL_CONVERSATIONS) {
+          break;
+        }
         if (!merged[diskId.id]) {
           let injectedWorkspaces: { workspaceFolderAbsoluteUri: string }[] = [];
           const wsId = conversationAffinity.get(diskId.id);

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -251,20 +251,19 @@ export function registerConversationRoutes(app: Hono): void {
       const diskIds = await scanDiskConversations(
         diskConversationDirs.length > 0 ? diskConversationDirs : undefined,
       );
-      // Sort diskIds by mtime descending so we prioritize warming up/displaying the most recent ones
-      diskIds.sort((a, b) => new Date(b.mtime).getTime() - new Date(a.mtime).getTime());
 
-      // Merge: disk-only sessions get minimal placeholder metadata.
-      // Actual workspace info will be resolved by the background warm-up below.
-      // We limit the total number of conversations returned to prevent UI lag
-      // and protect the LS from infinite warm-up eviction loops.
-      const diskOnlyIds: string[] = [];
-      const MAX_TOTAL_CONVERSATIONS = 100;
+      // Create a unified list of candidates combining LS-returned and disk-only ones
+      const candidates: { id: string; lastModifiedTime: string; summary: Record<string, unknown> }[] = [];
+
+      for (const [id, summary] of Object.entries(merged)) {
+        candidates.push({
+          id,
+          lastModifiedTime: typeof summary.lastModifiedTime === "string" ? summary.lastModifiedTime : "",
+          summary,
+        });
+      }
 
       for (const diskId of diskIds) {
-        if (Object.keys(merged).length >= MAX_TOTAL_CONVERSATIONS) {
-          break;
-        }
         if (!merged[diskId.id]) {
           let injectedWorkspaces: { workspaceFolderAbsoluteUri: string }[] = [];
           const wsId = conversationAffinity.get(diskId.id);
@@ -273,21 +272,46 @@ export function registerConversationRoutes(app: Hono): void {
             injectedWorkspaces = [{ workspaceFolderAbsoluteUri: uri }];
           }
 
-          // Always queue for warm-up, even with cached affinity.
-          // Affinity may be stale (LS restarted, conversation fell out of
-          // memory) — warm-up ensures the LS re-loads it from disk.
-          diskOnlyIds.push(diskId.id);
-
-          merged[diskId.id] = {
-            summary: diskId.id.slice(0, 8) + "…",
-            stepCount: 0,
-            status: "CASCADE_RUN_STATUS_UNLOADED",
+          candidates.push({
+            id: diskId.id,
             lastModifiedTime: diskId.mtime,
-            createdTime: diskId.mtime,
-            trajectoryId: "",
-            workspaces: injectedWorkspaces,
-            _diskOnly: true,
-          };
+            summary: {
+              summary: diskId.id.slice(0, 8) + "…",
+              stepCount: 0,
+              status: "CASCADE_RUN_STATUS_UNLOADED",
+              lastModifiedTime: diskId.mtime,
+              createdTime: diskId.mtime,
+              trajectoryId: "",
+              workspaces: injectedWorkspaces,
+              _diskOnly: true,
+            },
+          });
+        }
+      }
+
+      const parseTime = (t: unknown): number => {
+        if (typeof t === "string") {
+          const parsed = Date.parse(t);
+          if (!isNaN(parsed)) return parsed;
+        }
+        if (typeof t === "number") return t;
+        return 0;
+      };
+
+      // Sort candidates globally by lastModifiedTime desc
+      candidates.sort((a, b) => parseTime(b.lastModifiedTime) - parseTime(a.lastModifiedTime));
+
+      // Limit to MAX_TOTAL_CONVERSATIONS
+      const MAX_TOTAL_CONVERSATIONS = 100;
+      const topCandidates = candidates.slice(0, MAX_TOTAL_CONVERSATIONS);
+
+      const finalMerged: Record<string, Record<string, unknown>> = {};
+      const diskOnlyIds: string[] = [];
+
+      for (const cand of topCandidates) {
+        finalMerged[cand.id] = cand.summary;
+        if (cand.summary._diskOnly) {
+          diskOnlyIds.push(cand.id);
         }
       }
 
@@ -298,7 +322,7 @@ export function registerConversationRoutes(app: Hono): void {
         warmUpDiskConversations(diskOnlyIds, instances);
       }
 
-      return c.json({ trajectorySummaries: merged });
+      return c.json({ trajectorySummaries: finalMerged });
     } catch (err) {
       return handleRPCError(c, err);
     }


### PR DESCRIPTION
### Summary
This PR optimizes backend load performance and prevents Language Server memory thrashing by sorting disk conversations by modification time (`mtime`) descending and enforcing a cap on the maximum number of conversations merged/returned to the client.

### Rationale & Changes
- **Issue:** Previously, the proxy scanned and attempted to warm up *all* disk-only `.pb` files in a single poll cycle. If a user had hundreds of historical files, triggering simultaneous RPCs to the Language Server could overwhelm it. Because the LS maintains an in-memory limit, loading new sessions causes older ones to eject, resulting in infinite LS memory eviction/warm-up loops and noticeable frontend lag.
- **Solution:** 
  - **Prioritize Recency:** Sorted disk-scanned conversations by `mtime` descending to prioritize loading active and recently touched sessions.
  - **Enforce Limit (`MAX_TOTAL_CONVERSATIONS = 100`):** Set a cap of 100 on the total number of conversations merged (including LS active memory and disk placeholders). This ensures the payload size is predictable, the UI remains highly responsive, and the LS is protected from infinite eviction loops.
  - **On-demand fallback:** If a user accesses an older conversation (beyond the top 100) directly via URL, the LS auto-loads it on-demand through the direct fetch endpoint `/api/conversations/:id`.

### Verification
- Project builds successfully recursively (`corepack pnpm -r build`).
- Confirmed that the proxy correctly prioritizes recent files and limits the returned `trajectorySummaries` count to 100.