### PR TITLE
feat(web): group conversations by project name using desktop metadata fallback

### DIFF
--- a/packages/proxy/src/metadata.ts
+++ b/packages/proxy/src/metadata.ts
@@ -2,7 +2,7 @@
  * Shared metadata and disk-scanning utilities for the proxy.
  */
 
-import { readdir, stat } from "node:fs/promises";
+import { readdir, stat, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -174,4 +174,36 @@ export function withNormalizedConversationWorkspaces<T extends Record<string, un
   const workspaces = extractConversationWorkspaces(summary);
   if (workspaces.length === 0) return summary;
   return { ...summary, workspaces };
+}
+
+function safeDecodeUriComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export async function getProjectNameMap(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const projectsDir = join(homedir(), ".gemini", "config", "projects");
+  try {
+    const files = await readdir(projectsDir);
+    for (const file of files) {
+      if (file.endsWith(".json")) {
+        try {
+          const content = await readFile(join(projectsDir, file), "utf8");
+          const data = JSON.parse(content);
+          if (data.id && data.name) {
+            map.set(data.id, safeDecodeUriComponent(data.name));
+          }
+        } catch {
+          // ignore invalid json
+        }
+      }
+    }
+  } catch {
+    // projects dir missing or unreadable
+  }
+  return map;
 }

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -21,6 +21,7 @@ import {
   getPrimaryWorkspaceUri,
   scanDiskConversations,
   withNormalizedConversationWorkspaces,
+  getProjectNameMap,
 } from "../metadata.js";
 import { handleRPCError } from "../errors.js";
 import { runConversationMutation } from "../conversation-mutations.js";
@@ -168,6 +169,7 @@ function warmUpDiskConversations(
 export function registerConversationRoutes(app: Hono): void {
   app.get("/api/conversations", async (c) => {
     try {
+      const projectNameMap = await getProjectNameMap();
       const instances = await discovery.getInstances();
       const merged: Record<string, Record<string, unknown>> = {};
 
@@ -191,6 +193,15 @@ export function registerConversationRoutes(app: Hono): void {
             for (const [id, summary] of Object.entries(summaries)) {
               const normalizedSummary =
                 withNormalizedConversationWorkspaces(summary);
+
+              const projectId = (normalizedSummary.trajectoryMetadata as any)?.projectId;
+              if (projectId) {
+                const projectName = projectNameMap.get(projectId);
+                if (projectName) {
+                  (normalizedSummary as any).projectName = projectName;
+                }
+              }
+
               const wsUri = getPrimaryWorkspaceUri(normalizedSummary);
               if (wsUri) {
                 conversationAffinity.set(id, uriToWorkspaceId(wsUri));

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -45,6 +45,9 @@ function relativeTime(iso: string): string {
 }
 
 function extractWorkspaceName(conv: ConversationEntry): string {
+  if (conv.summary.projectName) {
+    return conv.summary.projectName;
+  }
   const name = workspaceNameFromMetadata(conv.summary.workspaces?.[0], {
     collapseAntigravityPlayground: true,
   });

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -8,6 +8,7 @@ export interface ConversationSummary {
   workspaces: Workspace[];
   lastUserInputTime?: string;
   lastUserInputStepIndex?: number;
+  projectName?: string;
 }
 
 export interface MediaAttachment {


### PR DESCRIPTION
### Summary
This PR aligns the remote web UI sidebar groups with the Antigravity desktop app project list by parsing project name metadata from the local projects configuration directory.

### Rationale & Changes
- **Proxy Backend**:
  - Implements `getProjectNameMap()` to load project IDs and decoded names from `~/.gemini/config/projects/`.
  - Inject `projectName` into conversation summaries served at `/api/conversations`.
- **Web UI**:
  - `Sidebar.tsx` extract workspace name prioritizes `projectName` when available, gracefully falling back to workspace name.