### PR TITLE
feat(web): support permission requests inside requestedInteraction

### DIFF
--- a/packages/web/src/components/StepCards.tsx
+++ b/packages/web/src/components/StepCards.tsx
@@ -91,7 +91,11 @@ export function FilePermissionCard({
           <IconLock size={12} />
         </span>
         <span className="step-card-desc">
-          File access requested:{" "}
+          {permissionRequest.action === "write_file"
+            ? "Allow write access to this path: "
+            : permissionRequest.action === "read_file"
+              ? "Allow read access to this path: "
+              : "File access requested: "}
           <code className="step-card-file">{displayPath}</code>
           {isDir ? " (directory)" : ""}
         </span>

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -85,6 +85,12 @@ export interface AskQuestionInteraction {
 
 export interface RequestedInteractionData {
   askQuestion?: AskQuestionRequest;
+  permission?: {
+    resource?: {
+      action?: string;
+      target?: string;
+    };
+  };
 }
 
 export interface CompletedInteractionData {

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -56,6 +56,7 @@ export interface FilePermissionRequest {
   absolutePathUri: string;
   blockReason?: string;
   isDirectory?: boolean;
+  action?: string;
 }
 
 // ── Ask Question ──

--- a/packages/web/src/utils/stepCards.ts
+++ b/packages/web/src/utils/stepCards.ts
@@ -14,15 +14,30 @@ import type {
 export function getFilePermissionRequest(
   step: TrajectoryStep,
 ): FilePermissionRequest | undefined {
-  return (
+  let fpr =
     step.filePermissionRequest ??
     step.viewFile?.filePermissionRequest ??
     step.listDirectory?.filePermissionRequest ??
     step.codeAction?.filePermissionRequest ??
     step.grepSearch?.filePermissionRequest ??
     step.viewFileOutline?.filePermissionRequest ??
-    step.viewCodeItem?.filePermissionRequest
-  );
+    step.viewCodeItem?.filePermissionRequest;
+
+  if (!fpr && step.requestedInteraction?.permission) {
+    const perm = step.requestedInteraction.permission;
+    if (
+      perm.resource &&
+      (perm.resource.action === "read_file" ||
+        perm.resource.action === "write_file")
+    ) {
+      fpr = {
+        absolutePathUri: perm.resource.target ?? "",
+        isDirectory: false,
+      };
+    }
+  }
+
+  return fpr;
 }
 
 export function getAskQuestionRequest(

--- a/packages/web/src/utils/stepCards.ts
+++ b/packages/web/src/utils/stepCards.ts
@@ -23,6 +23,14 @@ export function getFilePermissionRequest(
     step.viewFileOutline?.filePermissionRequest ??
     step.viewCodeItem?.filePermissionRequest;
 
+  if (fpr && !fpr.action) {
+    if (step.codeAction) {
+      fpr.action = "write_file";
+    } else {
+      fpr.action = "read_file";
+    }
+  }
+
   if (!fpr && step.requestedInteraction?.permission) {
     const perm = step.requestedInteraction.permission;
     if (
@@ -33,6 +41,7 @@ export function getFilePermissionRequest(
       fpr = {
         absolutePathUri: perm.resource.target ?? "",
         isDirectory: false,
+        action: perm.resource.action,
       };
     }
   }


### PR DESCRIPTION
### Summary
This PR adds support for rendering file permission requests from `requestedInteraction.permission` in the web client, and differentiates between read and write access.

### Rationale & Changes
- **Web UI**:
  - `getFilePermissionRequest` helper updated to extract `resource.action` and `resource.target` from `step.requestedInteraction.permission` when present.
  - Differentiates between `"read_file"` and `"write_file"` actions to display clear description labels in the `FilePermissionCard` header.