### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-30
+
+### Added
+
+- Sidebar conversations can now be grouped by Antigravity desktop project names
+  loaded from local project metadata, while still falling back to workspace
+  names when project metadata is unavailable. (#102)
+
+### Changed
+
+- Workspace lists are sorted by recent conversation activity, and active
+  workspaces without history stay easy to find near the top. (#99)
+- Workspace-less and warm-up conversations are now shown under a "No Workspace"
+  sidebar group instead of being hidden, making archived conversations
+  reachable again. (#99)
+
+### Fixed
+
+- Quick start documentation now points to the configured Vite dev UI port
+  (`3070`) instead of the Vite default (`5173`). (#104)
+
 ## [0.11.0] - 2026-06-21
 
 ### Added
@@ -234,7 +255,8 @@ Initial public release.
 - Remote access via Cloudflare Named Tunnel + Pages + Zero Trust
 - Cross-platform support: Linux (Tier 1), Windows (Tier 2), macOS (Tier 3)
 
-[Unreleased]: https://github.com/L1M80/porta/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/L1M80/porta/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/L1M80/porta/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/L1M80/porta/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/L1M80/porta/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/L1M80/porta/compare/v0.8.0...v0.9.0

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ git clone https://github.com/L1M80/porta.git
 cd porta
 pnpm install
 cp .env.example .env   # edit if needed — see comments inside
-pnpm dev               # proxy (:3170) + web (:5173)
+pnpm dev               # proxy (:3170) + web (:3070)
 ```
 
-Open `http://localhost:5173` in your browser.
+Open `http://localhost:3070` in your browser.
 
 ### LAN access
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/L1M80/porta/actions/workflows/ci.yml/badge.svg)](https://github.com/L1M80/porta/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-![Version](https://img.shields.io/badge/version-0.11.0-green)
+![Version](https://img.shields.io/badge/version-0.12.0-green)
 
 Remote web interface for [Antigravity](https://antigravity.google/) Agent Manager.  
 Access your local Antigravity sessions from your phone, tablet, or any remote browser through a lightweight LSP bridge.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "porta",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "dev": "node scripts/dev.mjs",

--- a/packages/proxy/src/metadata.ts
+++ b/packages/proxy/src/metadata.ts
@@ -2,7 +2,7 @@
  * Shared metadata and disk-scanning utilities for the proxy.
  */
 
-import { readdir, stat } from "node:fs/promises";
+import { readdir, stat, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -174,4 +174,36 @@ export function withNormalizedConversationWorkspaces<T extends Record<string, un
   const workspaces = extractConversationWorkspaces(summary);
   if (workspaces.length === 0) return summary;
   return { ...summary, workspaces };
+}
+
+function safeDecodeUriComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export async function getProjectNameMap(): Promise<Map<string, string>> {
+  const map = new Map<string, string>();
+  const projectsDir = join(homedir(), ".gemini", "config", "projects");
+  try {
+    const files = await readdir(projectsDir);
+    for (const file of files) {
+      if (file.endsWith(".json")) {
+        try {
+          const content = await readFile(join(projectsDir, file), "utf8");
+          const data = JSON.parse(content);
+          if (data.id && data.name) {
+            map.set(data.id, safeDecodeUriComponent(data.name));
+          }
+        } catch {
+          // ignore invalid json
+        }
+      }
+    }
+  } catch {
+    // projects dir missing or unreadable
+  }
+  return map;
 }

--- a/packages/proxy/src/routes/conversations.ts
+++ b/packages/proxy/src/routes/conversations.ts
@@ -21,6 +21,7 @@ import {
   getPrimaryWorkspaceUri,
   scanDiskConversations,
   withNormalizedConversationWorkspaces,
+  getProjectNameMap,
 } from "../metadata.js";
 import { handleRPCError } from "../errors.js";
 import { runConversationMutation } from "../conversation-mutations.js";
@@ -168,6 +169,7 @@ function warmUpDiskConversations(
 export function registerConversationRoutes(app: Hono): void {
   app.get("/api/conversations", async (c) => {
     try {
+      const projectNameMap = await getProjectNameMap();
       const instances = await discovery.getInstances();
       const merged: Record<string, Record<string, unknown>> = {};
 
@@ -191,6 +193,15 @@ export function registerConversationRoutes(app: Hono): void {
             for (const [id, summary] of Object.entries(summaries)) {
               const normalizedSummary =
                 withNormalizedConversationWorkspaces(summary);
+
+              const projectId = (normalizedSummary.trajectoryMetadata as any)?.projectId;
+              if (projectId) {
+                const projectName = projectNameMap.get(projectId);
+                if (projectName) {
+                  (normalizedSummary as any).projectName = projectName;
+                }
+              }
+
               const wsUri = getPrimaryWorkspaceUri(normalizedSummary);
               if (wsUri) {
                 conversationAffinity.set(id, uriToWorkspaceId(wsUri));

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -45,9 +45,10 @@ function relativeTime(iso: string): string {
 }
 
 function extractWorkspaceName(conv: ConversationEntry): string {
-  return workspaceNameFromMetadata(conv.summary.workspaces?.[0], {
+  const name = workspaceNameFromMetadata(conv.summary.workspaces?.[0], {
     collapseAntigravityPlayground: true,
   });
+  return name === "Others" ? "No Workspace" : name;
 }
 
 function isArchived(conv: ConversationEntry): boolean {
@@ -142,7 +143,6 @@ export function Sidebar({
     }
 
     return Array.from(map.entries())
-      .filter(([name]) => name !== "Others") // Hide workspace-less conversations
       .map(([name, convs]) => {
         // Sort within group: running first, then by lastModifiedTime desc
         convs.sort((a, b) => {
@@ -163,6 +163,10 @@ export function Sidebar({
         };
       })
       .sort((a, b) => {
+        // Keep "No Workspace" group at the bottom
+        if (a.name === "No Workspace" && b.name !== "No Workspace") return 1;
+        if (a.name !== "No Workspace" && b.name === "No Workspace") return -1;
+
         const aHasActive = a.conversations.some((c) => !isArchived(c));
         const bHasActive = b.conversations.some((c) => !isArchived(c));
         if (aHasActive !== bHasActive) return aHasActive ? -1 : 1;
@@ -177,6 +181,7 @@ export function Sidebar({
             new Date(c.summary.lastModifiedTime).getTime(),
           ),
         );
+
         return bTime - aTime;
       });
   }, [conversations]);

--- a/packages/web/src/components/Sidebar.tsx
+++ b/packages/web/src/components/Sidebar.tsx
@@ -45,6 +45,9 @@ function relativeTime(iso: string): string {
 }
 
 function extractWorkspaceName(conv: ConversationEntry): string {
+  if (conv.summary.projectName) {
+    return conv.summary.projectName;
+  }
   const name = workspaceNameFromMetadata(conv.summary.workspaces?.[0], {
     collapseAntigravityPlayground: true,
   });

--- a/packages/web/src/hooks/useWorkspaces.ts
+++ b/packages/web/src/hooks/useWorkspaces.ts
@@ -21,6 +21,7 @@ function uriFromSlug(
 interface ConversationEntry {
   id: string;
   summary: {
+    lastModifiedTime?: string;
     workspaces?: {
       workspaceFolderAbsoluteUri?: string;
       repository?: { computedName?: string };
@@ -47,14 +48,24 @@ export function useWorkspaces(
   const wsInitialized = useRef(false);
 
   useEffect(() => {
-    // Collect from conversations
+    // Collect from conversations and track their last modified time
     const fromConvs = new Map<string, string>();
+    const workspaceRecency = new Map<string, number>();
+
     for (const conv of conversations) {
       const ws = conv.summary.workspaces?.[0];
       if (!ws?.workspaceFolderAbsoluteUri) continue;
       const uri = ws.workspaceFolderAbsoluteUri;
       const name = workspaceNameFromMetadata(ws);
       fromConvs.set(uri, name);
+
+      const time = conv.summary.lastModifiedTime
+        ? new Date(conv.summary.lastModifiedTime).getTime()
+        : 0;
+      const existing = workspaceRecency.get(uri) ?? 0;
+      if (time > existing) {
+        workspaceRecency.set(uri, time);
+      }
     }
 
     // Collect from LS API
@@ -65,17 +76,38 @@ export function useWorkspaces(
           uri: w.workspaceUri,
           name: workspaceNameFromUri(w.workspaceUri),
         }));
+
+        // Assign a high score (current time) to active workspaces that don't have past conversations
+        // so that they stay at the very top of the list.
+        for (const w of fromApi) {
+          if (!workspaceRecency.has(w.uri)) {
+            workspaceRecency.set(w.uri, Date.now());
+          }
+        }
+
         const merged = new Map<string, string>();
         for (const w of fromApi) merged.set(w.uri, w.name);
         for (const [uri, name] of fromConvs) {
           if (!merged.has(uri)) merged.set(uri, name);
         }
+
         const list = Array.from(merged, ([uri, name]) => ({ uri, name }));
+        list.sort((a, b) => {
+          const timeA = workspaceRecency.get(a.uri) ?? 0;
+          const timeB = workspaceRecency.get(b.uri) ?? 0;
+          return timeB - timeA;
+        });
+
         setWorkspaces(list);
         wsInitialized.current = true;
       })
       .catch(() => {
         const list = Array.from(fromConvs, ([uri, name]) => ({ uri, name }));
+        list.sort((a, b) => {
+          const timeA = workspaceRecency.get(a.uri) ?? 0;
+          const timeB = workspaceRecency.get(b.uri) ?? 0;
+          return timeB - timeA;
+        });
         setWorkspaces(list);
         wsInitialized.current = true;
       });

--- a/packages/web/src/types/index.ts
+++ b/packages/web/src/types/index.ts
@@ -8,6 +8,7 @@ export interface ConversationSummary {
   workspaces: Workspace[];
   lastUserInputTime?: string;
   lastUserInputStepIndex?: number;
+  projectName?: string;
 }
 
 export interface MediaAttachment {


### PR DESCRIPTION
## Summary
- Release Porta v0.12.0
- Include sidebar recency/workspace visibility updates, Antigravity project-name grouping, and README dev port correction

## Verification
- `pnpm -r build`
- `pnpm -r test`